### PR TITLE
fix: beta banner bottom border missing on Home

### DIFF
--- a/src/.vuepress/components/BetaBanner.vue
+++ b/src/.vuepress/components/BetaBanner.vue
@@ -1,12 +1,6 @@
-<script>
-export default {}
-</script>
-
 <template>
   <aside class="beta-banner">
-    <p>
-      ⚠️ Beta Version: Docs are in development and subject to change.
-    </p>
+    <p>⚠️ Beta Version: Docs are in development and subject to change.</p>
   </aside>
 </template>
 
@@ -15,7 +9,7 @@ export default {}
 
 .beta-banner {
   position: fixed;
-  z-index: 20;
+  z-index: 21;
   top: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
This PR fixes the issue where the bottom border of the "Docs in beta" banner is missing on homepage.

Before:

![image](https://user-images.githubusercontent.com/8056274/87823316-5ae56a00-c873-11ea-98ee-aff0ef8b33a6.png)

After:

![image](https://user-images.githubusercontent.com/8056274/87823298-55881f80-c873-11ea-989b-3427a3dcf82f.png)
