### PR TITLE
fix(migration/functional-component): typo DynamicHeading

### DIFF
--- a/src/guide/migration/functional-components.md
+++ b/src/guide/migration/functional-components.md
@@ -77,7 +77,7 @@ const DynamicHeading = (props, context) => {
 
 DynamicHeading.props = ['level']
 
-export default GreetingMessage
+export default DynamicHeading
 ```
 
 ### Single File Components (SFCs)


### PR DESCRIPTION
In [Migration - Functional Components](https://v3.vuejs.org/guide/migration/functional-components.html#components-created-by-functions), I believe that:

```js
export default GreetingMessage
```

should instead be 

```js
export default DynamicHeading
```

 