### PR TITLE
fix: use proper flat vnode format in example.

### DIFF
--- a/src/guide/migration/render-function-api.md
+++ b/src/guide/migration/render-function-api.md
@@ -116,9 +116,9 @@ In 3.x, the entire VNode props structure is flattened. Using the example from ab
 {
   class: ['button', 'is-outlined'],
   style: { color: '#34495E' },
-  attrs: { id: 'submit' },
+  id: 'submit',
   innerHTML: '',
-  on: { click: submitForm },
+  onClick: submitForm,
   key: 'submit-button'
 }
 ```


### PR DESCRIPTION
Migration guide -> render functions

The last example didn't use the new flat vnode format for all properties. This PR fixes that.