### PR TITLE
fix: use current directives API

### DIFF
--- a/src/guide/migration/global-api-treeshaking.md
+++ b/src/guide/migration/global-api-treeshaking.md
@@ -93,11 +93,13 @@ In addition to public APIs, many of the internal components/helpers are now expo
 is compiled into something similar to the following:
 
 ```js
-import { h, Transition, applyDirectives, vShow } from 'vue'
+import { h, Transition, withDirectives, vShow } from 'vue'
 
 export function render() {
   return h(Transition, [
-    applyDirectives(h('div', 'hello'), this, [vShow, this.ok])
+    withDirectives(h('div', 'hello'), [
+      [vShow, this.ok]
+    ])
   ])
 }
 ```


### PR DESCRIPTION
Directives API was changed a while ago: the function was renamed, it no longer requires to provide a current instance and directives should be passed in an array as opposed to being passed as function arguments.