### PR TITLE
Clarify v-model usage history

### DIFF
--- a/src/guide/migration/v-model.md
+++ b/src/guide/migration/v-model.md
@@ -15,7 +15,7 @@ For more information, read on!
 
 ## Introduction
 
-In Vue 2, the `v-model` directive required developers to always use the `value` prop. And if developers required different props for different purposes, they would have to resort to using `v-bind.sync`. In addition, this hard-coded relationship between `v-model` and `value` led to issues with how native elements and custom elements were handled.
+When Vue 2.0 was released, the `v-model` directive required developers to always use the `value` prop. And if developers required different props for different purposes, they would have to resort to using `v-bind.sync`. In addition, this hard-coded relationship between `v-model` and `value` led to issues with how native elements and custom elements were handled.
 
 In 2.2 we introduced the `model` component option that allows the component to customize the prop and event to use for `v-model`. However, this still only allowed a single `v-model` to be used on the component.
 


### PR DESCRIPTION
This sentence threw me at first because i've been customizing v-model in Vue 2 for a long time! it comes clear later, but figured we could front-load the clarification.

