### PR TITLE
Update attribute coercion with respect to new behaviour

### DIFF
--- a/src/guide/template-syntax.md
+++ b/src/guide/template-syntax.md
@@ -60,7 +60,7 @@ In the case of boolean attributes, where their mere existence implies `true`, `v
 <button v-bind:disabled="isButtonDisabled">Button</button>
 ```
 
-If `isButtonDisabled` has the value of `null` or `undefined` attribute will not even be included in the rendered `<button>` element.
+If `isButtonDisabled` has the value of `null` or `undefined`, the `disabled` attribute will not even be included in the rendered `<button>` element.
 
 ### Using JavaScript Expressions
 

--- a/src/guide/template-syntax.md
+++ b/src/guide/template-syntax.md
@@ -60,7 +60,7 @@ In the case of boolean attributes, where their mere existence implies `true`, `v
 <button v-bind:disabled="isButtonDisabled">Button</button>
 ```
 
-If `isButtonDisabled` has the value of `null`, `undefined`, or `false`, the `disabled` attribute will not even be included in the rendered `<button>` element.
+If `isButtonDisabled` has the value of `null` or `undefined` attribute will not even be included in the rendered `<button>` element.
 
 ### Using JavaScript Expressions
 


### PR DESCRIPTION
Only `null` and `undefined` will result in no attribute in the final DOM, according to [RFC #24](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0024-attribute-coercion-behavior.md#detailed-design)

## Note

Thanks for your interest in submitting a PR! At this time, because the docs are in beta, the team is currently in the midst of changes and we are not ready for additional contributions yet.

To bring your issue to the team's attention though, we would recommend [creating an issue](https://github.com/vuejs/docs-next/issues/new) and we'll get to it when we can.

Thanks for your understanding!
