### PR TITLE
Clarify edge cases for directives attribute expression

### DIFF
--- a/src/guide/events.md
+++ b/src/guide/events.md
@@ -127,6 +127,29 @@ methods: {
 }
 ```
 
+## Multiple Event Handlers
+
+You can have multiple methods in an event handler separated by a comma operator like this:
+
+```html
+<!-- both one() and two() will execute on button click -->
+<button @click="one($event), two($event)">
+  Submit
+</button>
+```
+
+```js
+// ...
+methods: {
+  one(event) {
+    // first handler logic...
+  },
+  two(event) {
+    // second handler logic...
+  }
+}
+```
+
 ## Event Modifiers
 
 It is a very common need to call `event.preventDefault()` or `event.stopPropagation()` inside event handlers. Although we can do this easily inside methods, it would be better if the methods can be purely about data logic rather than having to deal with DOM event details.

--- a/src/guide/template-syntax.md
+++ b/src/guide/template-syntax.md
@@ -85,7 +85,7 @@ These expressions will be evaluated as JavaScript in the data scope of the owner
 
 ## Directives
 
-Directives are special attributes with the `v-` prefix. Directive attribute values are expected to be **a single JavaScript expression** (with the exception of `v-for`, which will be discussed later). A directive's job is to reactively apply side effects to the DOM when the value of its expression changes. Let's review the example we saw in the introduction:
+Directives are special attributes with the `v-` prefix. Directive attribute values are expected to be **a single JavaScript expression** (with the exception of `v-for` and `v-on`, which will be discussed later). A directive's job is to reactively apply side effects to the DOM when the value of its expression changes. Let's review the example we saw in the introduction:
 
 ```html
 <p v-if="seen">Now you see me</p>


### PR DESCRIPTION
You can as well express event listener bindings as the following:

```html
<input v-on:input="foo(), bar($event)">
```

Live example: https://vue-next-template-explorer.netlify.app/#%7B%22src%22%3A%22%3Cinput%20v-on%3Ainput%3D%5C%22foo()%2C%20bar(%24event)%5C%22%2F%3E%22%2C%22options%22%3A%7B%22mode%22%3A%22module%22%2C%22prefixIdentifiers%22%3Afalse%2C%22optimizeImports%22%3Afalse%2C%22hoistStatic%22%3Afalse%2C%22cacheHandlers%22%3Afalse%2C%22scopeId%22%3Anull%2C%22ssrCssVars%22%3A%22%7B%20color%20%7D%22%2C%22optimizeBindings%22%3Afalse%7D%7D

To be clear, it is technically a single expression that contains comma separated list of expressions which is perfectly valid. But this kind of expression does not work consistently across various directives and mustache syntax, so I think it should be included in edge cases.

## Note

Thanks for your interest in submitting a PR! At this time, because the docs are in beta, the team is currently in the midst of changes and we are not ready for additional contributions yet.

To bring your issue to the team's attention though, we would recommend [creating an issue](https://github.com/vuejs/docs-next/issues/new) and we'll get to it when we can.

Thanks for your understanding!
