### PR TITLE
Link to Reactivity in depth on Computed page

### DIFF
--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -93,6 +93,10 @@ computed: {
 }
 ```
 
+::: tip 
+To learn why `Date.now()` is not reactive please refer to [**Reactivity in Depth**](reactivity.html).
+:::
+
 In comparison, a method invocation will **always** run the function whenever a re-render happens.
 
 Why do we need caching? Imagine we have an expensive computed property `list`, which requires looping through a huge array and doing a lot of computations. Then we may have other computed properties that in turn depend on `list`. Without caching, we would be executing `list`’s getter many more times than necessary! In cases where you do not want caching, use a `method` instead.


### PR DESCRIPTION
It is not yet clear why `Date.now()` is not reactive at the current stage of learning progression, a sidenote with a link to Reactivity in Depth should resolve that issue.

## Note

Thanks for your interest in submitting a PR! At this time, because the docs are in beta, the team is currently in the midst of changes and we are not ready for additional contributions yet.

To bring your issue to the team's attention though, we would recommend [creating an issue](https://github.com/vuejs/docs-next/issues/new) and we'll get to it when we can.

Thanks for your understanding!
