### PR TITLE
fix: link to Global API Treeshaking

### DIFF
--- a/src/guide/migration/global-api.md
+++ b/src/guide/migration/global-api.md
@@ -72,7 +72,7 @@ An app instance exposes a subset of the current global APIs. The rule of thumb i
 | Vue.mixin                  | app.mixin                                                                                       |
 | Vue.use                    | app.use ([see below](#a-note-for-plugin-authors))                                               |
 
-All other global APIs that do not globally mutate behavior are now named exports, as documented in [Global API Treeshaking](./treeshaking.html).
+All other global APIs that do not globally mutate behavior are now named exports, as documented in [Global API Treeshaking](./global-api-treeshaking.html).
 
 ### `config.productionTip` Removed
 


### PR DESCRIPTION
The link to Global API Treeshaking somehow got broken. This PR should fix it.