### PR TITLE
fix: sidebar's top value

### DIFF
--- a/src/.vuepress/theme/styles/config.styl
+++ b/src/.vuepress/theme/styles/config.styl
@@ -1,3 +1,2 @@
 $contentClass = '.theme-default-content'
 $fontPrimary = 'Inter', Roboto, Oxygen, Fira Sans,Helvetica Neue, sans-serif;
-$betaBannerHeight = 3rem

--- a/src/.vuepress/theme/styles/index.styl
+++ b/src/.vuepress/theme/styles/index.styl
@@ -60,7 +60,7 @@ html.with-beta-banner
 
 html.with-beta-banner
   .sidebar
-    top 6.6rem // $navbarHeight + $betaBannerHeight
+    top calc(3.6rem + 37px)
 
 {$contentClass}:not(.custom)
   @extend $wrapper


### PR DESCRIPTION
Initially, the "beta" banner's height was hard-coded to be `3.3rem`, and other values were calculated based on it. Later on, however, this hard-coded value was removed, resulting in this super minor gap:

<img src="https://user-images.githubusercontent.com/8056274/87884788-11cb1c80-ca11-11ea-9089-100180031131.png" width="365"/>

This PR removes the gap (using another hard-coded value 😅).

<img src="https://user-images.githubusercontent.com/8056274/87884841-5e165c80-ca11-11ea-854e-4f78b0167d59.png" width="365"/>

