### PR TITLE
fix: sidebar's top padding on mobile devices

### DIFF
--- a/src/.vuepress/theme/styles/mobile.styl
+++ b/src/.vuepress/theme/styles/mobile.styl
@@ -13,8 +13,6 @@ $mobileSidebarWidth = $sidebarWidth * 0.82
 // wide mobile
 @media (max-width: $MQMobile)
   .sidebar
-    top $navbarHeight
-    padding-top $navbarHeight
     transform translateX(-100%)
     transition transform .2s ease
   .page


### PR DESCRIPTION
Not sure if I'm missing anything here, but currently the sidebar has a weird top padding on mobile:

<img src="https://user-images.githubusercontent.com/8056274/87884973-7b97f600-ca12-11ea-8be5-5f84d288f5e4.png" width="375">

This PR removes it:

<img src="https://user-images.githubusercontent.com/8056274/87884969-72a72480-ca12-11ea-92a9-d64d4c4ca7c2.png" width="375">
