### PR TITLE
fix: increase heading line-height to fix overlapping

### DIFF
--- a/src/.vuepress/theme/styles/index.styl
+++ b/src/.vuepress/theme/styles/index.styl
@@ -119,7 +119,7 @@ strong
 
 h1, h2, h3, h4, h5, h6
   font-weight 500
-  line-height 1.25
+  line-height 1.45
 
   {$contentClass}:not(.custom) > &
     margin-top (0.5rem - $navbarHeight)


### PR DESCRIPTION
The current line-height for headings (`1.25`) is a bit too small, causing some headings to overlap on smaller screens, e.g.,

<img src="https://user-images.githubusercontent.com/8056274/87907097-3ac8cd00-ca64-11ea-8807-21e865b087bb.png" width="325"/>

I've increased it a bit—just enough to eliminate the overlapping but not affect the overall look and feel (or so I hope 😅):

<img src="https://user-images.githubusercontent.com/8056274/87907081-300e3800-ca64-11ea-8a6f-77c4f303cdc3.png" width="325"/>
