### PR TITLE
fix: change directive inserted to mounted

### DIFF
--- a/src/guide/migration/global-api.md
+++ b/src/guide/migration/global-api.md
@@ -145,7 +145,7 @@ app.component('button-counter', {
 })
 
 app.directive('focus', {
-  inserted: el => el.focus()
+  mounted: el => el.focus()
 })
 
 // now every Vue instance mounted with app.mount(), along with its


### PR DESCRIPTION
In Vue 3,the directive lifecycle hooks are changed.
such as: inserted → mounted
The doc link is [https://v3.vuejs.org/guide/migration/custom-directives.html#_3-x-syntax](https://v3.vuejs.org/guide/migration/custom-directives.html#_3-x-syntax)

