### PR TITLE
Clarify emits API section

### DIFF
--- a/src/api/options-data.md
+++ b/src/api/options-data.md
@@ -290,3 +290,10 @@
     }
   })
   ```
+  
+  ::: tip Note
+  Events listed in the `emits` option **will not** be inherited by the root element of the component and also will be exlcluded from the `$attrs` property.
+  :::
+  
+
+- **See also:** [Attribute Inheritance](../guide/component-props.html#non-prop-attributes)


### PR DESCRIPTION
Add an explainer that:

1. Emits removes listeners from attribute inheritance
2. Emits removes listeners from the `$attrs` property

## Note

Thanks for your interest in submitting a PR! At this time, because the docs are in beta, the team is currently in the midst of changes and we are not ready for additional contributions yet.

To bring your issue to the team's attention though, we would recommend [creating an issue](https://github.com/vuejs/docs-next/issues/new) and we'll get to it when we can.

Thanks for your understanding!
