### PR TITLE
Improve Mixins page

### DIFF
--- a/src/guide/mixins.md
+++ b/src/guide/mixins.md
@@ -2,7 +2,7 @@
 
 ## Basics
 
-Mixins are a simple way to distribute reusable functionalities for Vue components. A mixin object can contain any component options. When a component uses a mixin, all options in the mixin will be "mixed" into the component's own options.
+Mixins distribute reusable functionalities for Vue components. A mixin object can contain any component options. When a component uses a mixin, all options in the mixin will be "mixed" into the component's own options.
 
 Example:
 

--- a/src/guide/mixins.md
+++ b/src/guide/mixins.md
@@ -2,7 +2,7 @@
 
 ## Basics
 
-Mixins are a flexible way to distribute reusable functionalities for Vue components. A mixin object can contain any component options. When a component uses a mixin, all options in the mixin will be "mixed" into the component's own options.
+Mixins are a simple way to distribute reusable functionalities for Vue components. A mixin object can contain any component options. When a component uses a mixin, all options in the mixin will be "mixed" into the component's own options.
 
 Example:
 
@@ -212,6 +212,8 @@ app.mixin({
   }
 })
 ```
+
+## Precautions
 
 In Vue 2, mixins were the primary tool to abstract parts of component logic into reusable chunks. However, they have a few issues:
 


### PR DESCRIPTION
State that:

1. Mixins are a __simple__ way to reuse component logic, rather than a flexible way to do it. The term __flexible__ goes into conflict with the last chapter of the page, which describes that mixins are in fact inflexible.
2. Add a section title for Precautions.

## Note

Thanks for your interest in submitting a PR! At this time, because the docs are in beta, the team is currently in the midst of changes and we are not ready for additional contributions yet.

To bring your issue to the team's attention though, we would recommend [creating an issue](https://github.com/vuejs/docs-next/issues/new) and we'll get to it when we can.

Thanks for your understanding!
