### PR TITLE
Adjust migration section grouping title to better reflect its contents

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -108,7 +108,7 @@ const sidebar = {
       ]
     },
     {
-      title: 'Migration to Vue 3',
+      title: 'Migration from Vue 2',
       collapsable: true,
       children: [
         'migration/introduction',


### PR DESCRIPTION
**Motivation**

* Pages under this section group reflect changes that happened only between Vue 2 and Vue 3. It does not help if you're migrating from Vue 1 for example.
* Since it is already a Vue 3 documentation calling migration section `Migration to Vue 3` is a bit of a tautology.
* This grouping does not reflect migration from other frameworks like React or Svelte.

## Note

Thanks for your interest in submitting a PR! At this time, because the docs are in beta, the team is currently in the midst of changes and we are not ready for additional contributions yet.

To bring your issue to the team's attention though, we would recommend [creating an issue](https://github.com/vuejs/docs-next/issues/new) and we'll get to it when we can.

Thanks for your understanding!
