### PR TITLE
fix: syntax highlighting example for multiple sections

### DIFF
--- a/src/guide/contributing/doc-style-guide.md
+++ b/src/guide/contributing/doc-style-guide.md
@@ -105,7 +105,7 @@ export default {
 #### Group of Lines
 
 ````
-```js{4-7}
+```js{4-5}
 export default {
   name: 'MyComponent',
   props: {


### PR DESCRIPTION
fixes an error in the doc-style-guide for syntax highlighting multiple sections