### PR TITLE
Update built-in meta component API section

### DIFF
--- a/src/api/built-in-components.md
+++ b/src/api/built-in-components.md
@@ -4,11 +4,13 @@
 
 - **Props:**
 
-  - `is` - `string | ComponentDefinition | ComponentConstructor`
+  - `is` - `string | Component`
 
 - **Usage:**
 
-  A "meta component" for rendering dynamic components. The actual component to render is determined by the `is` prop:
+  A "meta component" for rendering dynamic components. The actual component to render is determined by the `is` prop. An `is` prop as a string could be either an HTML tag name or a Component name.
+
+- **Example:**
 
   ```html
   <!-- a dynamic component controlled by -->
@@ -17,6 +19,12 @@
 
   <!-- can also render registered component or component passed as prop -->
   <component :is="$options.components.child"></component>
+
+  <!-- can reference components by string -->
+  <component :is="condition ? 'FooComponent' : 'BarComponent'"></component>
+
+  <!-- can be used to render native HTML elements -->
+  <component :is="href ? 'a' : 'span'"></component>
   ```
 
 - **See also:** [Dynamic Components](../guide/component-dynamic-async.html)


### PR DESCRIPTION
* Add more examples
* Clarify what `is` can actually accept as its value
* Remove redundant types (ComponentConstructor is not described anywhere)

## Note

Thanks for your interest in submitting a PR! At this time, because the docs are in beta, the team is currently in the midst of changes and we are not ready for additional contributions yet.

To bring your issue to the team's attention though, we would recommend [creating an issue](https://github.com/vuejs/docs-next/issues/new) and we'll get to it when we can.

Thanks for your understanding!
