### PR TITLE
fix: add missing comment in example

### DIFF
--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -89,6 +89,7 @@ Before we dive into render functions, it’s important to know a little about ho
 <div>
   <h1>My title</h1>
   Some text content
+  <!-- TODO: Add tagline -->
 </div>
 ```
 


### PR DESCRIPTION
There is a comment in the visualization that is missing from an example, this PR fixes the example code.
![image](https://user-images.githubusercontent.com/920747/87992004-925c4c80-cae7-11ea-916e-305750bce9d0.png)
