### PR TITLE
fix: use Vue component instead of `input` in v-model section

### DIFF
--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -276,7 +276,7 @@ props: ['modelValue'],
 render() {
   return Vue.h(SomeComponent, {
     modelValue: this.modelValue,
-    'onUpdate:modelValue': value => this.$emit('onUpdate:modelValue', value)
+    'onUpdate:modelValue': value => this.$emit('update:modelValue', value)
   })
 }
 ```

--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -274,7 +274,7 @@ The `v-model` directive is expanded to `modelValue` and `onUpdate:modelValue` pr
 ```js
 props: ['modelValue'],
 render() {
-  return Vue.h('input', {
+  return Vue.h(SomeComponent, {
     modelValue: this.modelValue,
     'onUpdate:modelValue': value => this.$emit('onUpdate:modelValue', value)
   })


### PR DESCRIPTION
Using `v-model` with `input` is still the same as in Vue 2, this was changed only when using with Vue components.