### PR TITLE
Vueschool links

### DIFF
--- a/src/guide/class-and-style.md
+++ b/src/guide/class-and-style.md
@@ -3,6 +3,7 @@
 A common need for data binding is manipulating an element's class list and its inline styles. Since they are both attributes, we can use `v-bind` to handle them: we only need to calculate a final string with our expressions. However, meddling with string concatenation is annoying and error-prone. For this reason, Vue provides special enhancements when `v-bind` is used with `class` and `style`. In addition to strings, the expressions can also evaluate to objects or arrays.
 
 ## Binding HTML Classes
+<VideoLesson href="https://vueschool.io/lessons/vuejs-dynamic-classes?friend=vuejs" title="Free Vue.js Dynamic Classes Lesson">Watch a free video lesson on Vue School</VideoLesson>
 
 ### Object Syntax
 

--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -1,5 +1,7 @@
 # Components Basics
 
+<VideoLesson href="https://vueschool.io/courses/vuejs-components-fundamentals?friend=vuejs" title="Free Vue.js Components Fundamentals Course">Watch a free video course on Vue School</VideoLesson>
+
 ## Base Example
 
 Here's an example of a Vue component:

--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -2,8 +2,6 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
-<div class="vueschool"><a href="https://vueschool.io/lessons/communication-between-components?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to work with custom events on Vue School">Learn how to work with custom events in a free Vue School lesson</a></div>
-
 ## Event Names
 
 Like components and props, event names provide an automatic case transformation. If you emit an event from the child component in camel case, you will be able to add a kebab-cased listener in the parent:

--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -2,6 +2,8 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/communication-between-components?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to work with custom events on Vue School">Learn how to work with custom events in a free Vue School lesson</a></div>
+
 ## Event Names
 
 Like components and props, event names provide an automatic case transformation. If you emit an event from the child component in camel case, you will be able to add a kebab-cased listener in the parent:

--- a/src/guide/component-props.md
+++ b/src/guide/component-props.md
@@ -2,6 +2,8 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/reusable-components-with-props?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how component props work with Vue School">Learn how component props work with a free lesson on Vue School</a></div>
+
 ## Prop Types
 
 So far, we've only seen props listed as an array of strings:

--- a/src/guide/component-props.md
+++ b/src/guide/component-props.md
@@ -2,7 +2,7 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
-<div class="vueschool"><a href="https://vueschool.io/lessons/reusable-components-with-props?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how component props work with Vue School">Learn how component props work with a free lesson on Vue School</a></div>
+<VideoLesson href="https://vueschool.io/lessons/reusable-components-with-props?friend=vuejs" title="Learn how component props work with Vue School">Learn how component props work with a free lesson on Vue School</VideoLesson>
 
 ## Prop Types
 

--- a/src/guide/component-registration.md
+++ b/src/guide/component-registration.md
@@ -2,6 +2,8 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
+<VideoLesson href="https://vueschool.io/lessons/global-vs-local-components?friend=vuejs" title="Free Vue.js Component Registration lesson">Watch a free video lesson on Vue School</VideoLesson>
+
 ## Component Names
 
 When registering a component, it will always be given a name. For example, in the global registration we've seen so far:

--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -2,6 +2,8 @@
 
 ## Computed Properties
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/vuejs-computed-properties?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how computed properties work with Vue School">Learn how computed properties work with a free lesson on Vue School</a></div>
+
 In-template expressions are very convenient, but they are meant for simple operations. Putting too much logic in your templates can make them bloated and hard to maintain. For example, if we have an object with a nested array:
 
 ```js

--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -2,7 +2,7 @@
 
 ## Computed Properties
 
-<div class="vueschool"><a href="https://vueschool.io/lessons/vuejs-computed-properties?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how computed properties work with Vue School">Learn how computed properties work with a free lesson on Vue School</a></div>
+<VideoLesson href="https://vueschool.io/lessons/vuejs-computed-properties?friend=vuejs" title="Learn how computed properties work with Vue School">Learn how computed properties work with a free lesson on Vue School</VideoLesson>
 
 In-template expressions are very convenient, but they are meant for simple operations. Putting too much logic in your templates can make them bloated and hard to maintain. For example, if we have an object with a nested array:
 

--- a/src/guide/conditional.md
+++ b/src/guide/conditional.md
@@ -1,5 +1,7 @@
 # Conditional Rendering
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/vuejs-conditionals?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how conditional rendering works with Vue School">Learn how conditional rendering works with a free lesson on Vue School</a></div>
+
 ## `v-if`
 
 The directive `v-if` is used to conditionally render a block. The block will only be rendered if the directive's expression returns a truthy value.

--- a/src/guide/conditional.md
+++ b/src/guide/conditional.md
@@ -1,6 +1,6 @@
 # Conditional Rendering
 
-<div class="vueschool"><a href="https://vueschool.io/lessons/vuejs-conditionals?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how conditional rendering works with Vue School">Learn how conditional rendering works with a free lesson on Vue School</a></div>
+<VideoLesson href="https://vueschool.io/lessons/vuejs-conditionals?friend=vuejs" title="Learn how conditional rendering works with Vue School">Learn how conditional rendering works with a free lesson on Vue School</VideoLesson>
 
 ## `v-if`
 

--- a/src/guide/events.md
+++ b/src/guide/events.md
@@ -1,5 +1,7 @@
 # Event Handling
 
+<VideoLesson href="https://vueschool.io/lessons/vuejs-user-events?friend=vuejs" title="Learn how to handle events on Vue School">Learn how to handle events in a free Vue School lesson</VideoLesson>
+
 ## Listening to Events
 
 We can use the `v-on` directive, which we typically shorten to the `@` symbol, to listen to DOM events and run some JavaScript when they're triggered. The usage would be `v-on:click="methodName"` or with the shortcut, `@click="methodName"`

--- a/src/guide/instance.md
+++ b/src/guide/instance.md
@@ -87,6 +87,8 @@ Vue also exposes some built-in properties via the component instance, such as `$
 
 ## Lifecycle Hooks
 
+<VideoLesson href="https://vueschool.io/lessons/understanding-the-vuejs-lifecycle-hooks?friend=vuejs" title="Free Vue.js Lifecycle Hooks Lesson">Watch a free lesson on Vue School</VideoLesson>
+
 Each component instance goes through a series of initialization steps when it's created - for example, it needs to set up data observation, compile the template, mount the instance to the DOM, and update the DOM when data changes. Along the way, it also runs functions called **lifecycle hooks**, giving users the opportunity to add their own code at specific stages.
 
 For example, the [created](../api/options-lifecycle-hooks.html#created) hook can be used to run code after an instance is created:

--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -1,6 +1,6 @@
 # List Rendering
 
-<div class="vueschool"><a href="https://vueschool.io/lessons/vuejs-loops?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to render lists on Vue School">Learn how to render list with a free Vue School lesson</a></div>
+<VideoLesson href="https://vueschool.io/lessons/vuejs-loops?friend=vuejs" title="Learn how to render lists on Vue School">Learn how to render list with a free Vue School lesson</VideoLesson>
 
 ## Mapping an Array to Elements with `v-for`
 

--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -1,5 +1,7 @@
 # List Rendering
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/vuejs-loops?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to render lists on Vue School">Learn how to render list with a free Vue School lesson</a></div>
+
 ## Mapping an Array to Elements with `v-for`
 
 We can use the `v-for` directive to render a list of items based on an array. The `v-for` directive requires a special syntax in the form of `item in items`, where `items` is the source data array and `item` is an **alias** for the array element being iterated on:

--- a/src/guide/single-file-component.md
+++ b/src/guide/single-file-component.md
@@ -2,6 +2,8 @@
 
 ## Introduction
 
+<VideoLesson href="https://vueschool.io/lessons/introduction-to-single-file-components?friend=vuejs" title="Free Vue.js Single File Components lesson">Watch a free video lesson on Vue School</VideoLesson>
+
 In many Vue projects, global components will be defined using `app.component()`, followed by `app.mount('#app')` to target a container element in the body of every page.
 
 This can work very well for small to medium-sized projects, where JavaScript is only used to enhance certain views. In more complex projects however, or when your frontend is entirely driven by JavaScript, these disadvantages become apparent:


### PR DESCRIPTION
This PR adds the approved Vue School links that were added to the Vue 2 documentation in [PR 2379](https://github.com/vuejs/vuejs.org/pull/2379). 

I've made no changes to the links, they are identical to the Vue 2 version. [Screenshots of the placements can be seen here](https://imgur.com/a/j6rkptp)

**Lessons**
[Computed Properties](https://vueschool.io/lessons/vuejs-computed-properties)
[Reusable Components with Props](https://vueschool.io/lessons/reusable-components-with-props)
[Conditional Rendering](https://vueschool.io/lessons/vuejs-conditionals)
[List Rendering](https://vueschool.io/lessons/vuejs-loops)
[Communication between Components with Custom Events](https://vueschool.io/lessons/communication-between-components)
