### PR TITLE
docs: added video explanation links for Vue 3

### DIFF
--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -6,6 +6,8 @@
 Reaching this far in the documentation, you should already be familiar with both [the basics of Vue](introduction.md) and [creating components](component-basics.md).
 :::
 
+[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/why-the-composition-api)
+
 Creating Vue components allows us to extract repeatable parts of the interface coupled with its functionality into reusable pieces of code. This alone can get our application pretty far in terms of maintainability and flexibility. However, our collective experience has proved that this alone might not be enough, especially when your application is getting really big – think several hundreds of components. When dealing with such large applications, sharing and reusing code becomes especially important.
 
 Let’s imagine that in our app, we have a view to show a list of repositories of a certain user. On top of that, we want to apply search and filter capabilities. Our component handling this view could look like this:
@@ -65,6 +67,8 @@ It would be much nicer if we could collocate code related to the same logical co
 Now that we know the **why** we can get to the **how**. To start working with the Compsition API we first need a place where we can actually use it. In a Vue component, we call this place the `setup`.
 
 ### `setup` Component Option
+
+[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/setup-and-reactive-references)
 
 The new `setup` component option is executed **before** the component is created, once the `props` are resolved, and serves as the entry point for composition API's.
 

--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -6,7 +6,7 @@
 Reaching this far in the documentation, you should already be familiar with both [the basics of Vue](introduction.md) and [creating components](component-basics.md).
 :::
 
-[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/why-the-composition-api)
+[Watch a free video about the Composition API on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/why-the-composition-api)
 
 Creating Vue components allows us to extract repeatable parts of the interface coupled with its functionality into reusable pieces of code. This alone can get our application pretty far in terms of maintainability and flexibility. However, our collective experience has proved that this alone might not be enough, especially when your application is getting really big – think several hundreds of components. When dealing with such large applications, sharing and reusing code becomes especially important.
 
@@ -68,7 +68,7 @@ Now that we know the **why** we can get to the **how**. To start working with th
 
 ### `setup` Component Option
 
-[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/setup-and-reactive-references)
+[Watch a free video about setup on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/setup-and-reactive-references)
 
 The new `setup` component option is executed **before** the component is created, once the `props` are resolved, and serves as the entry point for composition API's.
 

--- a/src/guide/composition-api-lifecycle-hooks.md
+++ b/src/guide/composition-api-lifecycle-hooks.md
@@ -2,7 +2,7 @@
 
 > This guide assumes that you have already read the [Composition API Introduction](composition-api-introduction.html) and [Reactivity Fundamentals](reactivity-fundamentals.html). Read that first if you are new to Composition API.
 
-[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/lifecycle-hooks)
+[Watch a free video about Lifecycle Hooks on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/lifecycle-hooks)
 
 You can access a component's lifecycle hook by prefixing the lifecycle hook with "on".
 

--- a/src/guide/composition-api-lifecycle-hooks.md
+++ b/src/guide/composition-api-lifecycle-hooks.md
@@ -2,6 +2,8 @@
 
 > This guide assumes that you have already read the [Composition API Introduction](composition-api-introduction.html) and [Reactivity Fundamentals](reactivity-fundamentals.html). Read that first if you are new to Composition API.
 
+[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/lifecycle-hooks)
+
 You can access a component's lifecycle hook by prefixing the lifecycle hook with "on".
 
 The following table contains how the lifecycle hooks are invoked inside of [setup()](composition-api-setup.html):

--- a/src/guide/reactivity.md
+++ b/src/guide/reactivity.md
@@ -2,7 +2,7 @@
 
 Now it’s time to take a deep dive! One of Vue’s most distinct features is the unobtrusive reactivity system. Models are proxied JavaScript objects. When you modify them, the view updates. It makes state management simple and intuitive, but it’s also important to understand how it works to avoid some common gotchas. In this section, we are going to dig into some of the lower-level details of Vue’s reactivity system.
 
-[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-reactivity/vue3-reactivity)
+[Watch a free video about Reactivity on Vue Mastery](https://www.vuemastery.com/courses/vue-3-reactivity/vue3-reactivity)
 
 ## What is Reactivity?
 

--- a/src/guide/reactivity.md
+++ b/src/guide/reactivity.md
@@ -2,6 +2,8 @@
 
 Now it’s time to take a deep dive! One of Vue’s most distinct features is the unobtrusive reactivity system. Models are proxied JavaScript objects. When you modify them, the view updates. It makes state management simple and intuitive, but it’s also important to understand how it works to avoid some common gotchas. In this section, we are going to dig into some of the lower-level details of Vue’s reactivity system.
 
+[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-reactivity/vue3-reactivity)
+
 ## What is Reactivity?
 
 This term comes up in programming quite a bit these days, but what do people mean when they say it? Reactivity is a programming paradigm that allows us to adjust to changes in a declarative manner. The canonical example that people usually show, because it’s a great one, is an excel spreadsheet.

--- a/src/guide/teleport.md
+++ b/src/guide/teleport.md
@@ -1,5 +1,7 @@
 # Teleport
 
+[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/teleport)
+
 Vue encourages us to build our UIs by encapsulating UI and related behavior into components. We can nest them inside one another to build a tree that makes up an application UI.
 
 However, sometimes a part of a component's template belongs into this component logically, while from a technical point of view, it would be preferable to move this part of the template somewhere else in the DOM, outside of Vue app. For example, due to styling requirements, we want to move `<p id="content">` from it's deeply nested position to the `<div>` with `id="endofbody"`

--- a/src/guide/teleport.md
+++ b/src/guide/teleport.md
@@ -1,6 +1,6 @@
 # Teleport
 
-[Watch a Video Explanation on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/teleport)
+[Watch a free video about Teleport on Vue Mastery](https://www.vuemastery.com/courses/vue-3-essentials/teleport)
 
 Vue encourages us to build our UIs by encapsulating UI and related behavior into components. We can nest them inside one another to build a tree that makes up an application UI.
 


### PR DESCRIPTION
We have a few lessons that should help with Vue 3 learning.  They are all free.

Ultimately these should be turned into play buttons like on the original documentation, but @bencodezen encouraged me to use Markdown for now.

![image](https://user-images.githubusercontent.com/2618/88071823-51ddec80-cb42-11ea-8bf7-f704bf7c4a4d.png)

Feel free to modify and move if needed.
