### PR TITLE
feat: Add `watch` changes

### DIFF
--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -38,8 +38,6 @@
 
       // function for watching a single nested property
       this.$watch(
-        // Only `this.c.d` will be watched
-        // `this.c.e` will not be watched
         () => this.c.d,
         (newVal, oldVal) => {
           // do something

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -14,7 +14,7 @@
 
 - **Usage:**
 
-  Watch an expression or a computed function on the Vue instance for changes. The callback gets called with the new value and the old value. The expression only accepts top-level data and component property names. For more complex expressions, use a function instead.
+  Watch a string expression or a computed function on the Vue instance for changes. The callback gets called with the new value and the old value. The string expression only accepts top-level data and component property names. For more complex expressions, use a function instead.
 
 - **Example:**
 

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -31,7 +31,7 @@
       }
     },
     created() {
-      // keypath
+      // top-level property name
       this.$watch('a', (newVal, oldVal) => {
         // do something
       })

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -25,7 +25,8 @@
         a: 1,
         b: 2,
         c: {
-          d: 3
+          d: 3,
+          e: 4
         }
       }
     },
@@ -37,6 +38,8 @@
 
       // function for watching a deep path
       this.$watch(
+        // Only `this.c.d` will be watched
+        // `this.c.e` will not be watched
         () => this.c.d,
         (newVal, oldVal) => {
           // do something

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -14,7 +14,7 @@
 
 - **Usage:**
 
-  Watch a string expression or a computed function on the Vue instance for changes. The callback gets called with the new value and the old value. The string expression only accepts top-level data and component property names. For more complex expressions, use a function instead.
+  Watch a reactive property or a computed function on the Vue instance for changes. The callback gets called with the new value and the old value for the given property. We can only pass top-level `data`, `prop`, or `computed` property name as a string. For more complex expressions or nested properties, use a function instead.
 
 - **Example:**
 
@@ -36,7 +36,7 @@
         // do something
       })
 
-      // function for watching a deep path
+      // function for watching a single nested property
       this.$watch(
         // Only `this.c.d` will be watched
         // `this.c.e` will not be watched

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -14,7 +14,7 @@
 
 - **Usage:**
 
-  Watch an expression or a computed function on the Vue instance for changes. The callback gets called with the new value and the old value. The expression only accepts dot-delimited paths. For more complex expressions, use a function instead.
+  Watch an expression or a computed function on the Vue instance for changes. The callback gets called with the new value and the old value. The expression only accepts top-level data and component property names. For more complex expressions, use a function instead.
 
 - **Example:**
 

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -23,7 +23,10 @@
     data() {
       return {
         a: 1,
-        b: 2
+        b: 2,
+        c: {
+          d: 3
+        }
       }
     },
     created() {
@@ -32,7 +35,15 @@
         // do something
       })
 
-      // function
+      // function for watching a deep path
+      this.$watch(
+        () => this.c.d,
+        (newVal, oldVal) => {
+          // do something
+        }
+      )
+
+      // function for watching a complex expression
       this.$watch(
         // every time the expression `this.a + this.b` yields a different result,
         // the handler will be called. It's as if we were watching a computed

--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -38,6 +38,7 @@ The following consists a list of breaking changes from 2.x:
 - Some transition classes got a rename:
   - `v-enter` -> `v-enter-from`
   - `v-leave` -> `v-leave-from`
+- [Component watch option](/api/options-data.html#watch) and [instance method `$watch`](/api/instance-methods.html#watch) no longer supports dot-delimited string paths, use a computed function as the parameter instead
 
 ### Removed
 


### PR DESCRIPTION
Added explanation about breaking changes to component `watch` option and `$watch` instance method. Updated the related explanation and added an example for clarification.

See:
- https://codepen.io/yusufkandemir/pen/KKVJKBQ

- https://github.com/vuejs/vue-next/issues/671

- Current source code:
https://github.com/vuejs/vue-next/blob/288b4eab9e10187eb14d4d6d54dc9f077343a2a5/packages/runtime-core/src/apiWatch.ts#L308-L320