### PR TITLE
Removed "internals" chapter with duplicate guides

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -42,15 +42,6 @@ const sidebar = {
       ]
     },
     {
-      title: 'Internals',
-      collapsable: false,
-      children: [
-        '/guide/reactivity',
-        '/guide/optimizations',
-        '/guide/change-detection'
-      ]
-    },
-    {
       title: 'Reusability & Composition',
       collapsable: false,
       children: [


### PR DESCRIPTION
Relation https://github.com/vuejs/docs-next/issues/318

Remove `internals` guid.  It has duplicate guides.

https://github.com/vuejs/docs-next/blob/master/src/.vuepress/config.js#L71
https://github.com/vuejs/docs-next/blob/master/src/.vuepress/config.js#L86-L87

It was probably degrade in https://github.com/vuejs/docs-next/pull/243

