### PR TITLE
Reword preference of Vue Testing Library over Vue Test Utils

### DIFF
--- a/src/guide/testing.md
+++ b/src/guide/testing.md
@@ -86,7 +86,7 @@ Its guiding principle is that the more tests resemble the way software is used, 
 
 #### Vue Test Utils
 
-Vue Test Utils is the low-level component testing library that was written to provide users access to Vue specific APIs. While it is officially maintained, we recommend most users use Vue Testing Library, which is an abstraction over Vue Test Utils. 
+Vue Test Utils is the official low-level component testing library that was written to provide users access to Vue specific APIs. If you are starting testing Vue applications, we would recommend using Vue Testing Library, which is an abstraction over Vue Test Utils. 
 
 **Resources**
 

--- a/src/guide/testing.md
+++ b/src/guide/testing.md
@@ -86,7 +86,7 @@ Its guiding principle is that the more tests resemble the way software is used, 
 
 #### Vue Test Utils
 
-Vue Test Utils is the official low-level component testing library that was written to provide users access to Vue specific APIs. If you are starting testing Vue applications, we would recommend using Vue Testing Library, which is an abstraction over Vue Test Utils. 
+Vue Test Utils is the official low-level component testing library that was written to provide users access to Vue specific APIs. If you are new to testing Vue applications, we would recommend using Vue Testing Library, which is an abstraction over Vue Test Utils. 
 
 **Resources**
 


### PR DESCRIPTION
This PR aims to clarify the statement where the official docs recommend Vue Testing Library over Vue Test Utils (the official library).

When developing [the new version of VTU](https://github.com/vuejs/vue-test-utils-next/), we wanted to frame it as an “enabling” library. VTU 2 is both a **complete library to test out components**, and also a baseline to build other tools – We even developed a plugin system. This means that VTU is still a valid choice, and that there's no need to rewrite any codebase from VTU to Vue Testing Library.

During conversarions, we agreed that Vue Testing Library had a terser, useful API and that we should recommend it to newcomers.

Closes #326