### PR TITLE
Add readonly import to code sample

### DIFF
--- a/src/guide/reactivity-fundamentals.md
+++ b/src/guide/reactivity-fundamentals.md
@@ -150,6 +150,8 @@ You can learn more about `refs` in the [Refs API](../api/refs-api.html#ref) sect
 Sometimes we want to track changes of the reactive object (`ref` or `reactive`) but we also want prevent changing it from a certain place of the application. For example, when we have a [provided](component-provide-inject.html) reactive object, we want to prevent mutating it where it's injected. To do so, we can create a readonly proxy to the original object:
 
 ```js
+import { reactive, readonly } from 'vue'
+
 const original = reactive({ count: 0 })
 
 const copy = readonly(original)


### PR DESCRIPTION
Not completely sure the rules for when to have the vue imports in code samples, but not having this one threw me because the ones directly above do have the imports, and it seems each vue function is imported at least once in the example code.

I spent some time checking if readonly was a native javascript feature of proxies since I've never actually worked with them. Showing the import should quickly clear up where it's coming form.