### PR TITLE
feat(search): update search to DocSearch v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "vuepress build src"
   },
   "dependencies": {
+    "@docsearch/js": "^1.0.0-alpha.27",
+    "@docsearch/css": "^1.0.0-alpha.27",
     "axios": "^0.19.1",
     "showdown": "^1.9.1"
   }

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -277,7 +277,11 @@ module.exports = {
       '/community/': sidebar.guide,
       '/api/': sidebar.api
     },
-    smoothScroll: false
+    smoothScroll: false,
+    algolia: {
+      indexName: 'vuejs-v3',
+      apiKey: 'bc6e8acb44ed4179c30d0a45d6140d3f'
+    }
   },
   plugins: [
     [

--- a/src/.vuepress/theme/components/AlgoliaSearchBox.vue
+++ b/src/.vuepress/theme/components/AlgoliaSearchBox.vue
@@ -41,12 +41,8 @@ export default {
     },
     initialize (userOptions, lang) {
       Promise.all([
-        import(
-          /* webpackChunkName: "docsearch" */ '../node_modules/@docsearch/js'
-        ),
-        import(
-          /* webpackChunkName: "docsearch" */ '../node_modules/@docsearch/css'
-        )
+        import(/* webpackChunkName: "docsearch" */ '@docsearch/js'),
+        import(/* webpackChunkName: "docsearch" */ '@docsearch/css')
       ]).then(([docsearch]) => {
         docsearch = docsearch.default
 
@@ -58,7 +54,7 @@ export default {
             userOptions,
             {
               container: '#docsearch',
-              // #697 Make docsearch work well at i18n mode.
+              // #697 Make DocSearch work well in i18n mode.
               searchParameters: Object.assign(
                 {},
                 // lang && {

--- a/src/.vuepress/theme/components/AlgoliaSearchBox.vue
+++ b/src/.vuepress/theme/components/AlgoliaSearchBox.vue
@@ -1,28 +1,22 @@
 <template>
-  <form
-    id="search-form"
-    class="algolia-search-wrapper search-box"
-    role="search"
-  >
-    <input
-      id="algolia-search-input"
-      class="search-query"
-      :placeholder="placeholder"
-    >
-  </form>
+  <div id="docsearch"></div>
 </template>
 
 <script>
+function isSpecialClick(event) {
+  return (
+    event.button === 1 ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey
+  )
+}
+
 export default {
   name: 'AlgoliaSearchBox',
 
   props: ['options'],
-
-  data () {
-    return {
-      placeholder: undefined
-    }
-  },
 
   watch: {
     $lang (newValue) {
@@ -36,135 +30,124 @@ export default {
 
   mounted () {
     this.initialize(this.options, this.$lang)
-    this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
   },
 
   methods: {
+    getRelativePath (absoluteUrl) {
+      const { pathname, hash } = new URL(absoluteUrl)
+      const url = pathname.replace(this.$site.base, '/') + hash
+
+      return url
+    },
     initialize (userOptions, lang) {
       Promise.all([
-        import(/* webpackChunkName: "docsearch" */ 'docsearch.js/dist/cdn/docsearch.min.js'),
-        import(/* webpackChunkName: "docsearch" */ 'docsearch.js/dist/cdn/docsearch.min.css')
+        import(
+          /* webpackChunkName: "docsearch" */ '../node_modules/@docsearch/js'
+        ),
+        import(
+          /* webpackChunkName: "docsearch" */ '../node_modules/@docsearch/css'
+        )
       ]).then(([docsearch]) => {
         docsearch = docsearch.default
-        const { algoliaOptions = {}} = userOptions
-        docsearch(Object.assign(
-          {},
-          userOptions,
-          {
-            inputSelector: '#algolia-search-input',
-            // #697 Make docsearch work well at i18n mode.
-            algoliaOptions: Object.assign({
-              'facetFilters': [`lang:${lang}`].concat(algoliaOptions.facetFilters || [])
-            }, algoliaOptions),
-            handleSelected: (input, event, suggestion) => {
-              const { pathname, hash } = new URL(suggestion.url)
-              const routepath = pathname.replace(this.$site.base, '/')
-              this.$router.push(`${routepath}${hash}`)
+
+        docsearch(
+          Object.assign(
+            {
+              placeholder: this.$site.themeConfig.searchPlaceholder
+            },
+            userOptions,
+            {
+              container: '#docsearch',
+              // #697 Make docsearch work well at i18n mode.
+              searchParameters: Object.assign(
+                {},
+                // lang && {
+                //   facetFilters: [`lang:${lang}`].concat(
+                //     userOptions.facetFilters || []
+                //   )
+                // },
+                userOptions.searchParameters
+              ),
+              navigator: {
+                navigate: ({ suggestionUrl }) => {
+                  const { pathname: hitPathname } = new URL(
+                    window.location.origin + suggestionUrl
+                  )
+
+                  // Vue Router doesn't handle same-page navigation so we use
+                  // the native browser location API for anchor navigation.
+                  if (this.$router.history.current.path === hitPathname) {
+                    window.location.assign(
+                      window.location.origin + suggestionUrl
+                    )
+                  } else {
+                    this.$router.push(suggestionUrl)
+                  }
+                }
+              },
+              transformItems: items => {
+                return items.map(item => {
+                  return Object.assign({}, item, {
+                    url: this.getRelativePath(item.url)
+                  })
+                })
+              },
+              hitComponent: ({ hit, children }) => {
+                return {
+                  type: 'a',
+                  ref: undefined,
+                  constructor: undefined,
+                  key: undefined,
+                  props: {
+                    href: hit.url,
+                    onClick: event => {
+                      if (isSpecialClick(event)) {
+                        return
+                      }
+
+                      // We rely on the native link scrolling when user is
+                      // already on the right anchor because Vue Router doesn't
+                      // support duplicated history entries.
+                      if (this.$router.history.current.fullPath === hit.url) {
+                        return
+                      }
+
+                      const { pathname: hitPathname } = new URL(
+                        window.location.origin + hit.url
+                      )
+
+                      // If the hits goes to another page, we prevent the native link behavior
+                      // to leverage the Vue Router loading feature.
+                      if (this.$router.history.current.path !== hitPathname) {
+                        event.preventDefault()
+                      }
+
+                      this.$router.push(hit.url)
+                    },
+                    children
+                  }
+                }
+              }
             }
-          }
-        ))
+          )
+        )
       })
     },
 
-    update (options, lang) {
-      this.$el.innerHTML = '<input id="algolia-search-input" class="search-query">'
+    update(options, lang) {
+      this.$el.innerHTML = '<div id="docsearch"></div>'
       this.initialize(options, lang)
     }
   }
 }
 </script>
 
-<style lang="stylus">
-.algolia-search-wrapper
-  & > span
-    vertical-align middle
-  .algolia-autocomplete
-    line-height normal
-    .ds-dropdown-menu
-      background-color #fff
-      border 1px solid #999
-      border-radius 4px
-      font-size 16px
-      margin 6px 0 0
-      padding 4px
-      text-align left
-      &:before
-        border-color #999
-      [class*=ds-dataset-]
-        border none
-        padding 0
-      .ds-suggestions
-        margin-top 0
-      .ds-suggestion
-        border-bottom 1px solid $borderColor
-    .algolia-docsearch-suggestion--highlight
-      color #2c815b
-    .algolia-docsearch-suggestion
-      border-color $borderColor
-      padding 0
-      .algolia-docsearch-suggestion--category-header
-        padding 5px 10px
-        margin-top 0
-        background $accentColor
-        color #fff
-        font-weight 600
-        .algolia-docsearch-suggestion--highlight
-          background rgba(255, 255, 255, 0.6)
-      .algolia-docsearch-suggestion--wrapper
-        padding 0
-      .algolia-docsearch-suggestion--title
-        font-weight 600
-        margin-bottom 0
-        color $textColor
-      .algolia-docsearch-suggestion--subcategory-column
-        vertical-align top
-        padding 5px 7px 5px 5px
-        border-color $borderColor
-        background #f1f3f5
-        &:after
-          display none
-      .algolia-docsearch-suggestion--subcategory-column-text
-        color #555
-    .algolia-docsearch-footer
-      border-color $borderColor
-    .ds-cursor .algolia-docsearch-suggestion--content
-      background-color #e7edf3 !important
-      color $textColor
+<style lang="scss">
+@import '@theme/styles/_settings.scss';
 
-@media (min-width: $MQMobile)
-  .algolia-search-wrapper
-    .algolia-autocomplete
-      .algolia-docsearch-suggestion
-        .algolia-docsearch-suggestion--subcategory-column
-          float none
-          width 150px
-          min-width 150px
-          display table-cell
-        .algolia-docsearch-suggestion--content
-          float none
-          display table-cell
-          width 100%
-          vertical-align top
-        .ds-dropdown-menu
-          min-width 515px !important
-
-@media (max-width: $MQMobile)
-  .algolia-search-wrapper
-    .ds-dropdown-menu
-      min-width calc(100vw - 4rem) !important
-      max-width calc(100vw - 4rem) !important
-    .algolia-docsearch-suggestion--wrapper
-      padding 5px 7px 5px 5px !important
-    .algolia-docsearch-suggestion--subcategory-column
-      padding 0 !important
-      background white !important
-    .algolia-docsearch-suggestion--subcategory-column-text:after
-      content " > "
-      font-size 10px
-      line-height 14.4px
-      display inline-block
-      width 5px
-      margin -3px 3px 0
-      vertical-align middle
-
+.DocSearch {
+  --docsearch-primary-color: #{$green};
+  --docsearch-highlight-color: var(--docsearch-primary-color);
+  --docsearch-searchbox-shadow: inset 0 0 0 2px var(--docsearch-primary-color);
+}
 </style>

--- a/src/.vuepress/theme/components/Navbar.vue
+++ b/src/.vuepress/theme/components/Navbar.vue
@@ -23,11 +23,17 @@
         'max-width': linksWrapMaxWidth + 'px'
       } : {}"
     >
-      <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
       <SearchBox
-        v-else-if="$site.themeConfig.search !== false && $page.frontmatter.search !== false"
+        v-if="
+          isAlgoliaSearch === false &&
+            !(
+              $site.themeConfig.search !== false &&
+              $page.frontmatter.search !== false
+            )
+        "
       />
       <NavLinks class="can-hide" />
+      <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
     </div>
   </header>
 </template>

--- a/src/.vuepress/theme/package.json
+++ b/src/.vuepress/theme/package.json
@@ -21,6 +21,8 @@
   "author": "Ben Hong",
   "main": "index.js",
   "dependencies": {
+    "@docsearch/js": "^1.0.0-alpha.26",
+    "@docsearch/css": "^1.0.0-alpha.26",
     "@vuepress/plugin-active-header-links": "^1.3.1",
     "@vuepress/plugin-nprogress": "^1.3.1",
     "@vuepress/plugin-search": "^1.3.1",

--- a/src/.vuepress/theme/package.json
+++ b/src/.vuepress/theme/package.json
@@ -21,12 +21,9 @@
   "author": "Ben Hong",
   "main": "index.js",
   "dependencies": {
-    "@docsearch/js": "^1.0.0-alpha.26",
-    "@docsearch/css": "^1.0.0-alpha.26",
     "@vuepress/plugin-active-header-links": "^1.3.1",
     "@vuepress/plugin-nprogress": "^1.3.1",
     "@vuepress/plugin-search": "^1.3.1",
-    "docsearch.js": "^2.5.2",
     "lodash": "^4.17.15",
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.2",


### PR DESCRIPTION
> This PR is a follow-up of [@NataliaTepluhina's tweet](https://twitter.com/N_Tepluhina/status/1290965571023130624).

Hello Vue team! This PR integrates the **new version of DocSearch, that better reflects what we think documentation search should be**.

## Description

Reducing users' efforts to get them started integrating your product is key to adoption. We created [DocSearch](https://docsearch.algolia.com) in 2015 as a community effort to solve this problem.

We've had time to try different approaches since then and would like to propose you a new documentation search experience. This new experience has been well received and is now live on the Docusaurus v2 integration: facebook/docusaurus#2815.

## Preview

![Video preview](https://user-images.githubusercontent.com/6137112/89410219-9b722e00-d723-11ea-9c9d-2c052282fda1.gif)

| Mobile | Desktop |
|-|-|
| ![Mobile preview](https://user-images.githubusercontent.com/6137112/89410156-809fb980-d723-11ea-8e53-7bded3ceb094.png) | ![Desktop preview](https://user-images.githubusercontent.com/6137112/89410188-8dbca880-d723-11ea-94cf-57b80df2c8f9.png) |

## Changes

You can read about all the new features in the Docusaurus PR (facebook/docusaurus#2815), but here's a summary:

- We replaced the dropdown list for a modal
- You can open the search modal with <kbd>Ctrl + K</kbd>, <kbd>⌘ + K</kbd> or <kbd>/</kbd>
- No hard refresh (we leverage the Vue Router navigation API in this integration)
- The experience works on mobile and is close to a native mobile experience
- Recent searches
- Favorite searches
- Selection search
- Search suggestions
- Offline detection

## Notes

I'm not too familiar with VuePress so feel free to use this PR as a base branch, not as-is.

## What's next

This new DocSearch version has been used in production for a couple of weeks now, on the [DocSearch website](http://docsearch.algolia.com/) and on a few [Docusaurus v2](https://v2.docusaurus.io/) integrations.

This version is marked as alpha for now because the underlying libraries that we use (e.g., `autocomplete-core`) are still being worked on at @algolia to make sure that it handles more cases than DocSearch and usual autocomplete search experiences. We plan to go stable in the coming weeks but no major changes will happen to DocSearch.

Let us know what you think!