### PR TITLE
feat: migrate examples

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -178,7 +178,8 @@ const sidebar = {
         '/examples/grid-component',
         '/examples/tree-view',
         '/examples/svg',
-        '/examples/modal'
+        '/examples/modal',
+        '/examples/elastic-header'
       ]
     }
   ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -175,7 +175,8 @@ const sidebar = {
       children: [
         '/examples/markdown',
         '/examples/commits',
-        '/examples/grid-component'
+        '/examples/grid-component',
+        '/examples/tree-view'
       ]
     }
   ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -176,7 +176,8 @@ const sidebar = {
         '/examples/markdown',
         '/examples/commits',
         '/examples/grid-component',
-        '/examples/tree-view'
+        '/examples/tree-view',
+        '/examples/svg'
       ]
     }
   ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -174,7 +174,8 @@ const sidebar = {
       collapsable: false,
       children: [
         '/examples/markdown',
-        '/examples/commits'
+        '/examples/commits',
+        '/examples/grid-component'
       ]
     }
   ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -173,7 +173,8 @@ const sidebar = {
       title: 'Examples',
       collapsable: false,
       children: [
-        '/examples/markdown'
+        '/examples/markdown',
+        '/examples/commits'
       ]
     }
   ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -179,7 +179,8 @@ const sidebar = {
         '/examples/tree-view',
         '/examples/svg',
         '/examples/modal',
-        '/examples/elastic-header'
+        '/examples/elastic-header',
+        '/examples/select2'
       ]
     }
   ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -167,6 +167,15 @@ const sidebar = {
       ]
     },
     '/api/composition-api'
+  ],
+  examples: [
+    {
+      title: 'Examples',
+      collapsable: false,
+      children: [
+        '/examples/markdown'
+      ]
+    }
   ]
 }
 
@@ -213,7 +222,8 @@ module.exports = {
         ariaLabel: 'Documentation Menu',
         items: [
           { text: 'Guide', link: '/guide/introduction' },
-          { text: 'Style Guide', link: '/style-guide/' }
+          { text: 'Style Guide', link: '/style-guide/' },
+          { text: 'Examples', link: '/examples/markdown' }
         ]
       },
       { text: 'API Reference', link: '/api/application-config' },
@@ -275,7 +285,8 @@ module.exports = {
       collapsable: false,
       '/guide/': sidebar.guide,
       '/community/': sidebar.guide,
-      '/api/': sidebar.api
+      '/api/': sidebar.api,
+      '/examples/': sidebar.examples
     },
     smoothScroll: false
   },

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -177,7 +177,8 @@ const sidebar = {
         '/examples/commits',
         '/examples/grid-component',
         '/examples/tree-view',
-        '/examples/svg'
+        '/examples/svg',
+        '/examples/modal'
       ]
     }
   ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -180,7 +180,8 @@ const sidebar = {
         '/examples/svg',
         '/examples/modal',
         '/examples/elastic-header',
-        '/examples/select2'
+        '/examples/select2',
+        '/examples/todomvc'
       ]
     }
   ]

--- a/src/examples/commits.md
+++ b/src/examples/commits.md
@@ -1,0 +1,10 @@
+# GitHub Commits
+
+> This example fetches latest Vue.js commits data from GitHub’s API and displays them as a list. You can switch between the master and dev branches.
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="dyMopgW" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/dyMopgW">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/commits.md
+++ b/src/examples/commits.md
@@ -2,9 +2,9 @@
 
 > This example fetches latest Vue.js commits data from GitHub’s API and displays them as a list. You can switch between the master and dev branches.
 
-<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="dyMopgW" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
-  <span>See the Pen <a href="https://codepen.io/immarina/pen/dyMopgW">
-  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+<p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="RwaWmzY" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Commits">
+  <span>See the Pen <a href="https://codepen.io/team/Vue/pen/RwaWmzY">
+  Vue 3 Commits</a> by Vue (<a href="https://codepen.io/Vue">@Vue</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/elastic-header.md
+++ b/src/examples/elastic-header.md
@@ -1,0 +1,8 @@
+# Elastic Header Example
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="ZEWGmar" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/ZEWGmar">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/grid-component.md
+++ b/src/examples/grid-component.md
@@ -1,0 +1,10 @@
+# Grid Component
+
+> This is an example of creating a reusable grid component and using it with external data.
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="wvGaJEx" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/wvGaJEx">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/grid-component.md
+++ b/src/examples/grid-component.md
@@ -2,9 +2,9 @@
 
 > This is an example of creating a reusable grid component and using it with external data.
 
-<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="wvGaJEx" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
-  <span>See the Pen <a href="https://codepen.io/immarina/pen/wvGaJEx">
-  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+<p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="zYqvQgw" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Elastic Draggable Header Example">
+  <span>See the Pen <a href="https://codepen.io/team/Vue/pen/zYqvQgw">
+  Vue 3 Elastic Draggable Header Example</a> by Vue (<a href="https://codepen.io/Vue">@Vue</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/markdown.md
+++ b/src/examples/markdown.md
@@ -1,6 +1,6 @@
 # Markdown Editor
 
-A simple Markdown editor
+> A simple Markdown editor
 
 <p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="oNxXzyB" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
   <span>See the Pen <a href="https://codepen.io/immarina/pen/oNxXzyB">

--- a/src/examples/markdown.md
+++ b/src/examples/markdown.md
@@ -1,0 +1,10 @@
+# Markdown Editor
+
+A simple Markdown editor
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="oNxXzyB" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/oNxXzyB">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/modal.md
+++ b/src/examples/modal.md
@@ -2,9 +2,9 @@
 
 > Features used: component, prop passing, content insertion, transitions.
 
-<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="oNxXWKa" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
-  <span>See the Pen <a href="https://codepen.io/immarina/pen/oNxXWKa">
-  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+<p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="css,result" data-user="Vue" data-slug-hash="BaKoeXe" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/team/Vue/pen/BaKoeXe">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/Vue">@Vue</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/modal.md
+++ b/src/examples/modal.md
@@ -1,0 +1,10 @@
+# Modal Component
+
+> Features used: component, prop passing, content insertion, transitions.
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="oNxXWKa" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/oNxXWKa">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/select2.md
+++ b/src/examples/select2.md
@@ -1,0 +1,10 @@
+# Wrapper Component Example
+
+> In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="zYqGMWJ" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/zYqGMWJ">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/select2.md
+++ b/src/examples/select2.md
@@ -2,9 +2,9 @@
 
 > In this example we are integrating a 3rd party jQuery plugin (select2) by wrapping it inside a custom component.
 
-<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="zYqGMWJ" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
-  <span>See the Pen <a href="https://codepen.io/immarina/pen/zYqGMWJ">
-  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+<p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="eYZpwOB" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Wrapper Component Example">
+  <span>See the Pen <a href="https://codepen.io/team/Vue/pen/eYZpwOB">
+  Vue 3 Wrapper Component Example</a> by Vue (<a href="https://codepen.io/Vue">@Vue</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/svg.md
+++ b/src/examples/svg.md
@@ -1,0 +1,10 @@
+# SVG Graph
+
+> This example showcases a combination of custom component, computed property, two-way binding and SVG support.
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="gOrpWQJ" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/gOrpWQJ">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/svg.md
+++ b/src/examples/svg.md
@@ -2,9 +2,9 @@
 
 > This example showcases a combination of custom component, computed property, two-way binding and SVG support.
 
-<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="gOrpWQJ" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
-  <span>See the Pen <a href="https://codepen.io/immarina/pen/gOrpWQJ">
-  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+<p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="XWdmLWM" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 SVG Graph Example">
+  <span>See the Pen <a href="https://codepen.io/team/Vue/pen/XWdmLWM">
+  Vue 3 SVG Graph Example</a> by Vue (<a href="https://codepen.io/Vue">@Vue</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/todomvc.md
+++ b/src/examples/todomvc.md
@@ -1,0 +1,16 @@
+# TodoMVC
+
+> This is a fully spec-compliant TodoMVC implementation in under 120 effective lines of JavaScript (excluding comments and blank lines).
+
+:::warning
+Note that if your web browser is configured to block 3rd-party data/cookies, the example below will not work, as the **localStorage** data will fail to be saved.
+
+Additionally, due to limitations on CodePen, hashtag navigation will not work.
+:::
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="ZEWGwaW" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/ZEWGwaW">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/todomvc.md
+++ b/src/examples/todomvc.md
@@ -8,9 +8,9 @@ Note that if your web browser is configured to block 3rd-party data/cookies, the
 Additionally, due to limitations on CodePen, hashtag navigation will not work.
 :::
 
-<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="ZEWGwaW" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
-  <span>See the Pen <a href="https://codepen.io/immarina/pen/ZEWGwaW">
-  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+<p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="Yzqyozj" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 TodoMVC">
+  <span>See the Pen <a href="https://codepen.io/team/Vue/pen/Yzqyozj">
+  Vue 3 TodoMVC</a> by Vue (<a href="https://codepen.io/Vue">@Vue</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/tree-view.md
+++ b/src/examples/tree-view.md
@@ -1,0 +1,10 @@
+# Tree View
+
+> Example of a tree view implementation showcasing recursive usage of components.
+
+<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="gOrpWKy" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
+  <span>See the Pen <a href="https://codepen.io/immarina/pen/gOrpWKy">
+  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+  on <a href="https://codepen.io">CodePen</a>.</span>
+</p>
+<script async src="https://static.codepen.io/assets/embed/ei.js"></script>

--- a/src/examples/tree-view.md
+++ b/src/examples/tree-view.md
@@ -2,9 +2,9 @@
 
 > Example of a tree view implementation showcasing recursive usage of components.
 
-<p class="codepen" data-height="474" data-theme-id="39028" data-default-tab="js,result" data-user="immarina" data-slug-hash="gOrpWKy" style="height: 474px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Markdown Editor">
-  <span>See the Pen <a href="https://codepen.io/immarina/pen/gOrpWKy">
-  Vue 3 Markdown Editor</a> by Vue (<a href="https://codepen.io/immarina">@immarina</a>)
+<p class="codepen" data-height="300" data-theme-id="39028" data-default-tab="js,result" data-user="Vue" data-slug-hash="WNwQqbN" data-preview="true" data-editable="true" style="height: 300px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;" data-pen-title="Vue 3 Tree View">
+  <span>See the Pen <a href="https://codepen.io/team/Vue/pen/WNwQqbN">
+  Vue 3 Tree View</a> by Vue (<a href="https://codepen.io/Vue">@Vue</a>)
   on <a href="https://codepen.io">CodePen</a>.</span>
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>


### PR DESCRIPTION
Migrated most of the examples from Vue 2 to Vue 3 docs and into codepen

Note:

- Deepstream was removed due to missing API keys and API going into maintenance only
- Firebase + Validation was not ported due to `vuefire` not being 3.x ready. Confirmed with Posva
- Hackernews clone left for another PR due to complexity

These few should get us up and running with working examples for the docs though!

Issue: https://github.com/vuejs/docs-next/issues/25