### PR TITLE
docs: remove duplicate mention of section heading

### DIFF
--- a/src/guide/transitions-overview.md
+++ b/src/guide/transitions-overview.md
@@ -1,4 +1,4 @@
-# Transition & Animations Overview
+# Overview
 
 Vue offers some abstractions that can help work with transitions and animations, particularly in response to something changing. Some of these abstractions include:
 


### PR DESCRIPTION
## Before

<img width="284" alt="Screen Shot 2020-08-14 at 1 32 30 PM" src="https://user-images.githubusercontent.com/4836334/90277046-e29ea400-de32-11ea-87a4-c9d8d95c74c3.png">

## After

<img width="272" alt="Screen Shot 2020-08-14 at 1 33 44 PM" src="https://user-images.githubusercontent.com/4836334/90277060-e7fbee80-de32-11ea-849f-19ecc318c224.png">

## Note

This is minor, but I thought it helped to de-duplicate the sidebar section mention
