### PR TITLE
fix: MigrationBadges validator

### DIFF
--- a/src/.vuepress/components/MigrationBadges.vue
+++ b/src/.vuepress/components/MigrationBadges.vue
@@ -7,7 +7,7 @@ export default {
       type: Array,
       default: () => [],
       validator(value) {
-        return validBadges.includes(value)
+        return value.every(badge => validBadges.includes(badge))
       }
     }
   }


### PR DESCRIPTION
The `validator` for `MigrationBadges` is failing, resulting in console warnings in local builds of the docs.

The `value` is an array, not a string, so it needs to use `every` to test the array entries.