### PR TITLE
fix: computed example should not mutate ref value

### DIFF
--- a/src/guide/reactivity-computed-watchers.md
+++ b/src/guide/reactivity-computed-watchers.md
@@ -8,7 +8,7 @@ Sometimes we need state that depends on other state - in Vue this is handled wit
 
 ```js
 const count = ref(1)
-const plusOne = computed(() => count.value++)
+const plusOne = computed(() => count.value + 1)
 
 console.log(plusOne.value) // 2
 


### PR DESCRIPTION
There are two problems with the existing example:

1. Using `count.value++` changes the value of `count.value`.
2. Despite what it says on the next line, the logged value of `plusOne.value` will be 1, not 2. Note `count.value++` is being used, not `++count.value`.

Changing it to `count.value + 1` fixes both problems.