### PR TITLE
Add return values for Application API methods

### DIFF
--- a/src/api/application-api.md
+++ b/src/api/application-api.md
@@ -19,6 +19,11 @@ In addition, since the `createApp` method returns the application instance itsel
   - `{string} name`
   - `{Function | Object} [definition]`
 
+- **Returns:**
+
+  - The application instance if a `definition` argument was passed
+  - The component definition if a `definition` argument was not passed 
+
 - **Usage:**
 
   Register or retrieve a global component. Registration also automatically sets the component's `name` with the given `name` parameter.
@@ -35,8 +40,8 @@ app.component('my-component', {
   /* ... */
 })
 
-// retrieve a registered component (always return constructor)
-const MyComponent = app.component('my-component', {})
+// retrieve a registered component
+const MyComponent = app.component('my-component')
 ```
 
 - **See also:** [Components](../guide/component-basics.html)
@@ -64,6 +69,11 @@ app.config = {...}
 
   - `{string} name`
   - `{Function | Object} [definition]`
+
+- **Returns:**
+
+  - The application instance if a `definition` argument was passed
+  - The directive definition if a `definition` argument was not passed 
 
 - **Usage:**
 
@@ -156,6 +166,10 @@ Apart from `el`, you should treat these arguments as read-only and never modify 
 
   - `{Object} mixin`
 
+- **Returns:**
+
+  - The application instance 
+
 - **Usage:**
 
   Apply a mixin in the whole application scope. Once registered they can be used in the template of any component within the current application. This can be used by plugin authors to inject custom behavior into components. **Not recommended in application code**.
@@ -168,6 +182,10 @@ Apart from `el`, you should treat these arguments as read-only and never modify 
 
   - `{Element | string} rootContainer`
   - `{boolean} isHydrate`
+
+- **Returns:**
+
+  - The root component instance
 
 - **Usage:**
 
@@ -199,6 +217,10 @@ app.mount('#my-app')
   - `{string | Symbol} key`
   - `value`
 
+- **Returns:**
+
+  - The application instance
+
 - **Usage:**
 
   Sets a value that can be injected into all components within the application. Components should use `inject` to receive the provided values.
@@ -208,8 +230,6 @@ app.mount('#my-app')
   This method should not be confused with the [provide component option](options-composition.html#provide-inject) or the [provide function](composition-api.html#provide-inject) in the composition API. While those are also part of the same `provide`/`inject` mechanism, they are used to configure values provided by a component rather than an application. 
 
   Providing values via the application is especially useful when writing plugins, as plugins typically wouldn't be able to provide values using components. It is an alternative to using [globalProperties](application-config.html#globalproperties).
-
-  Returns the application instance, allowing calls to be chained.
 
   :::tip Note
   The `provide` and `inject` bindings are NOT reactive. This is intentional. However, if you pass down an observed object, properties on that object do remain reactive.
@@ -271,6 +291,10 @@ setTimeout(() => app.unmount('#my-app'), 5000)
 - **Arguments:**
 
   - `{Object | Function} plugin`
+
+- **Returns:**
+
+  - The application instance
 
 - **Usage:**
 


### PR DESCRIPTION
Fixes #423.

There didn't seem to be an established convention for what form these should take. I had a look at both the Vue 2 and Vue 3 docs before making some arbitrary choices:

1. No name or type. In other contexts I might have included the type but for these methods I didn't think `{Object}` really added anything.
2. The values are a sub-list within `Returns`, even though they typically only have a single list item.
3. For the complicated cases (`component` and `directive`) I went for two items in the list rather than trying to cram it all into a single item.
4. I used a capital letter at the start of each item but no full-stop at the end. My reasoning was that these aren't proper sentences, they're more like items on a shopping list or a to-do list.

I made a couple of other small changes, both of which are directly related to these return values.