### PR TITLE
isHydrate is optional

### DIFF
--- a/src/api/application-api.md
+++ b/src/api/application-api.md
@@ -181,7 +181,7 @@ Apart from `el`, you should treat these arguments as read-only and never modify 
 - **Arguments:**
 
   - `{Element | string} rootContainer`
-  - `{boolean} isHydrate`
+  - `{boolean} [isHydrate]`
 
 - **Returns:**
 


### PR DESCRIPTION
The `isHydrate` argument of `mount` is optional so I've added square brackets.