### PR TITLE
Indicate optional arguments with the word 'optional'

### DIFF
--- a/src/api/application-api.md
+++ b/src/api/application-api.md
@@ -17,7 +17,7 @@ In addition, since the `createApp` method returns the application instance itsel
 - **Arguments:**
 
   - `{string} name`
-  - `{Function | Object} [definition]`
+  - `{Function | Object} definition (optional)`
 
 - **Returns:**
 
@@ -68,7 +68,7 @@ app.config = {...}
 - **Arguments:**
 
   - `{string} name`
-  - `{Function | Object} [definition]`
+  - `{Function | Object} definition (optional)`
 
 - **Returns:**
 
@@ -181,7 +181,7 @@ Apart from `el`, you should treat these arguments as read-only and never modify 
 - **Arguments:**
 
   - `{Element | string} rootContainer`
-  - `{boolean} isHydrate`
+  - `{boolean} isHydrate (optional)`
 
 - **Returns:**
 
@@ -291,7 +291,7 @@ setTimeout(() => app.unmount('#my-app'), 5000)
 - **Arguments:**
 
   - `{Object | Function} plugin`
-  - `[...options]`
+  - `...options (optional)`
 
 - **Returns:**
 

--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -6,7 +6,7 @@
 
   - `{string | Function} source`
   - `{Function | Object} callback`
-  - `{Object} [options]`
+  - `{Object} options (optional)`
     - `{boolean} deep`
     - `{boolean} immediate`
 
@@ -177,7 +177,7 @@
 - **Arguments:**
 
   - `{string} eventName`
-  - `[...args]`
+  - `...args (optional)`
 
   Trigger an event on the current instance. Any additional arguments will be passed into the listener's callback function.
 
@@ -259,7 +259,7 @@
 
 - **Arguments:**
 
-  - `{Function} [callback]`
+  - `{Function} callback (optional)`
 
 - **Usage:**
 


### PR DESCRIPTION
This is in response to feedback on #432.

In that PR I attempted to put square brackets around the `isHydrate` argument of `mount` to mark it as optional. It was suggested that we should use the word `(optional)` instead, but that would have been inconsistent with other parts of the same page.

This PR changes all uses of square brackets to the `(optional)` format. It includes `isHydrate`, so #432 can be closed if this is merged.