### PR TITLE
docs: fix argument name

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -71,9 +71,9 @@ render() {
 
 ### Arguments
 
-Accepts three arguments: `tag`, `props` and `children`
+Accepts three arguments: `type`, `props` and `children`
 
-#### tag
+#### type
 
 - **Type:** `String | Object | Function | null`
 


### PR DESCRIPTION
the first argument name is `type` not `tag` of function `h`.
