### PR TITLE
Fix typo in composition-api-introduction.md

### DIFF
--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -62,7 +62,7 @@ It would be much nicer if we could collocate code related to the same logical co
 
 ## Basics of Composition API
 
-Now that we know the **why** we can get to the **how**. To start working with the Compsition API we first need a place where we can actually use it. In a Vue component, we call this place the `setup`.
+Now that we know the **why** we can get to the **how**. To start working with the Composition API we first need a place where we can actually use it. In a Vue component, we call this place the `setup`.
 
 ### `setup` Component Option
 


### PR DESCRIPTION
I've noticed this while reading the guide.