### PR TITLE
docs: update testing handbook link to Vue 3 vers.

### DIFF
--- a/src/guide/testing.md
+++ b/src/guide/testing.md
@@ -91,7 +91,7 @@ Vue Test Utils is the official low-level component testing library that was writ
 **Resources**
 
 - [Official Vue Test Utils Documentation](https://vue-test-utils.vuejs.org)
-- [Vue Testing Handbook](https://lmiller1990.github.io/vue-testing-handbook/#what-is-this-guide) by Lachlan Miller
+- [Vue Testing Handbook](https://lmiller1990.github.io/vue-testing-handbook/v3/#what-is-this-guide) by Lachlan Miller
 
 ## End-to-End (E2E) Testing
 


### PR DESCRIPTION
I updated my OSS book, the Vue Testing Handbook, to work with Vue.js 3 and VTU v2. This PR adds the correct link to the Vue 3 version of the book.