### PR TITLE
Adding free video links to supplement documentation

### DIFF
--- a/src/guide/class-and-style.md
+++ b/src/guide/class-and-style.md
@@ -1,5 +1,7 @@
 # Class and Style Bindings
 
+[Watch a free video about class & style bindings on Vue Mastery](https://www.vuemastery.com/courses/intro-to-vue-3/class-and-style-binding-vue3)
+
 A common need for data binding is manipulating an element's class list and its inline styles. Since they are both attributes, we can use `v-bind` to handle them: we only need to calculate a final string with our expressions. However, meddling with string concatenation is annoying and error-prone. For this reason, Vue provides special enhancements when `v-bind` is used with `class` and `style`. In addition to strings, the expressions can also evaluate to objects or arrays.
 
 ## Binding HTML Classes

--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -1,5 +1,7 @@
 # Components Basics
 
+[Watch a free video about component basics on Vue Mastery](https://www.vuemastery.com/courses/intro-to-vue-3/components-and-props-vue3)
+
 ## Base Example
 
 Here's an example of a Vue component:

--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -1,5 +1,7 @@
 # Form Input Bindings
 
+[Watch a free video about forms on Vue Mastery](https://www.vuemastery.com/courses/intro-to-vue-3/forms-and-v-model-vue3)
+
 ## Basic Usage
 
 You can use the `v-model` directive to create two-way data bindings on form input, textarea, and select elements. It automatically picks the correct way to update the element based on the input type. Although a bit magical, `v-model` is essentially syntax sugar for updating data on user input events, plus special care for some edge cases.

--- a/src/guide/instance.md
+++ b/src/guide/instance.md
@@ -14,6 +14,8 @@ After the instance is created, we can _mount_ it, passing a container to `mount`
 Vue.createApp(/* options */).mount('#app')
 ```
 
+[Watch a free video on creating a Vue application Vue Mastery](https://www.vuemastery.com/courses/intro-to-vue-3/creating-the-vue-app-vue3)
+
 Although not strictly associated with the [MVVM pattern](https://en.wikipedia.org/wiki/Model_View_ViewModel), Vue's design was partly inspired by it. As a convention, we often use the variable `vm` (short for ViewModel) to refer to our instance.
 
 When you create an instance, you pass in an **options object**. The majority of this guide describes how you can use these options to create your desired behavior. For reference, you can also browse the full list of options in the [API reference](../api/options-data.html).

--- a/src/guide/introduction.md
+++ b/src/guide/introduction.md
@@ -8,6 +8,8 @@ If you’d like to learn more about Vue before diving in, we <a id="modal-player
 
 If you are an experienced frontend developer and want to know how Vue compares to other libraries/frameworks, check out the [Comparison with Other Frameworks](TODO:comparison.html).
 
+[Watch a free video course on Vue Mastery](https://www.vuemastery.com/courses/intro-to-vue-3/intro-to-vue3)
+
 ## Getting Started
 
 <p>

--- a/src/guide/state-management.md
+++ b/src/guide/state-management.md
@@ -1,5 +1,7 @@
 # State Management
 
+[Watch a free video about Vuex on Vue Mastery](https://www.vuemastery.com/courses/mastering-vuex/intro-to-vuex)
+
 ## Official Flux-Like Implementation
 
 Large applications can often grow in complexity, due to multiple pieces of state scattered across many components and the interactions between them. To solve this problem, Vue offers [vuex](https://github.com/vuejs/vuex), our own Elm-inspired state management library. It even integrates into [vue-devtools](https://github.com/vuejs/vue-devtools), providing zero-setup access to [time travel debugging](https://raw.githubusercontent.com/vuejs/vue-devtools/master/media/demo.gif).

--- a/src/guide/template-syntax.md
+++ b/src/guide/template-syntax.md
@@ -48,6 +48,8 @@ Dynamically rendering arbitrary HTML on your website can be very dangerous becau
 
 ### Attributes
 
+[Watch a free video about attributes on Vue Mastery](https://www.vuemastery.com/courses/intro-to-vue-3/attribute-binding-vue3)
+
 Mustaches cannot be used inside HTML attributes. Instead, use a [`v-bind` directive](../api/#v-bind):
 
 ```html

--- a/src/guide/transitions-enterleave.md
+++ b/src/guide/transitions-enterleave.md
@@ -1,5 +1,7 @@
 # Enter & Leave Transitions
 
+[Watch a free video about transitions on Vue Mastery](https://www.vuemastery.com/courses/animating-vue/transitions)
+
 Vue provides a variety of ways to apply transition effects when items are inserted, updated, or removed from the DOM. This includes tools to:
 
 - automatically apply classes for CSS transitions and animations


### PR DESCRIPTION
Added free video links which give readers a visual option to learn core Vue.js concepts.  These videos don't require a lot of context switching, they're quick and basic, and they apply to Vue 3.

I purposely did not add free video links for topics listed in #311 Vue School links, though we do have videos which cover these topics.