### PR TITLE
Note that props can be accessed in template directly

### DIFF
--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -99,7 +99,7 @@ In other words, you **will not have access** to the following component options:
 
 ## Usage with Templates
 
-If `setup` returns an object, the properties on the object can be accessed in the component's template, as can the properties of the `props` passed in to `setup`:
+If `setup` returns an object, the properties on the object can be accessed in the component's template, as well as the properties of the `props` passed into `setup`:
 
 ```vue-html
 <!-- MyBook.vue -->

--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -99,19 +99,19 @@ In other words, you **will not have access** to the following component options:
 
 ## Usage with Templates
 
-If `setup` returns an object, the properties on the object can be accessed in the component's template:
+If `setup` returns an object, the properties on the object can be accessed in the component's template, as can the properties of the `props` passed in to `setup`:
 
 ```vue-html
 <!-- MyBook.vue -->
 <template>
-  <div>{{ readersNumber }} {{ book.title }}</div>
+  <div>{{ props.collectionName }}: {{ readersNumber }} {{ book.title }}</div>
 </template>
 
 <script>
   import { ref, reactive } from 'vue'
 
   export default {
-    setup() {
+    setup(props) {
       const readersNumber = ref(0)
       const book = reactive({ title: 'Vue 3 Guide' })
 


### PR DESCRIPTION
In "Usage with Templates" the doc shows how props of the object returned from `setup` can be used directly in the template, but I didn't find anywhere else in the composition-api doc where it says that props can also be used directly. This seemed like as good a place as any to add that, since that's where I was looking for it first :-).

## Description of Problem
Composition API doc doesn't mention that props can be used directly in templates

## Proposed Solution
I added a note and changed the example to use props.

## Additional Information
