### PR TITLE
docs: add Vue 3 video lessons

### DIFF
--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -23,6 +23,8 @@ For these reasons, we recommend you **always use kebab-case for event names**.
 
 ## Defining Custom Events
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/defining-custom-events-emits?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to define which events a component can emit with Vue School">Learn how to define emitted events with a free lesson on Vue School</a></div>
+
 Emitted events can be defined on the component via the `emits` option.
 
 ```js

--- a/src/guide/teleport.md
+++ b/src/guide/teleport.md
@@ -1,5 +1,7 @@
 # Teleport
 
+<div class="vueschool"><a href="https://vueschool.io/lessons/vue-3-teleport?friend=vuejs" target="_blank" rel="sponsored noopener" title="Learn how to use teleport with Vue School">Learn how to use teleport with a free lesson on Vue School</a></div>
+
 Vue encourages us to build our UIs by encapsulating UI and related behavior into components. We can nest them inside one another to build a tree that makes up an application UI.
 
 However, sometimes a part of a component's template belongs to this component logically, while from a technical point of view, it would be preferable to move this part of the template somewhere else in the DOM, outside of the Vue app. 


### PR DESCRIPTION
This PR adds links to free Vue 3 lessons from Vue School that complement the docs. The lessons are 1:1 with the concept in the docs.

**Lessons**

- [Emits option](https://vueschool.io/lessons/defining-custom-events-emits)
- [Teleport](https://vueschool.io/lessons/vue-3-teleport)

[Visuals](https://imgur.com/a/OoPjb9S)