### PR TITLE
fix: introduce the wrapper object to the props default example

### DIFF
--- a/src/guide/migration/props-default-this.md
+++ b/src/guide/migration/props-default-this.md
@@ -19,11 +19,13 @@ import { inject } from 'vue'
 
 export default {
   props: {
-    theme: props => {
-      // `props` is the raw values passed to the component,
-      // before any type / default coercions
-      // can also use `inject` to access injected properties
-      return inject('theme', 'default-theme')
+    theme: {
+      default (props) {
+        // `props` is the raw values passed to the component,
+        // before any type / default coercions
+        // can also use `inject` to access injected properties
+        return inject('theme', 'default-theme')
+      }
     }
   }
 }


### PR DESCRIPTION
## Description of Problem

The example of using `default` for `props` in the migration guide appears to be missing a wrapper object and `default` property.

I don't think the code as currently written will actually work. Testing with rc.13 seemed to need the extra object.

## Proposed Solution

Added the wrapper object.