### PR TITLE
Include tiny-emitter in events API migration strategy

### DIFF
--- a/src/guide/migration/events-api.md
+++ b/src/guide/migration/events-api.md
@@ -58,6 +58,6 @@ We removed `$on`, `$off` and `$once` methods from the instance completely. `$emi
 
 ## Migration Strategy
 
-Existing event hubs can be replaced by using an external library implementing the event emitter interface, for example [mitt](https://github.com/developit/mitt).
+Existing event hubs can be replaced by using an external library implementing the event emitter interface, for example [mitt](https://github.com/developit/mitt) or [tiny-emitter](https://github.com/scottcorgan/tiny-emitter).
 
 These methods can also be supported in compatibility builds.


### PR DESCRIPTION
## Description of Problem

In the migration guide, it suggest using [mitt](https://github.com/developit/mitt) to migrate existing event hubs, but its interface is incompatible with Vue 2 where:
1. mitt's [emit](https://github.com/developit/mitt/blob/22c5dcba10736aecb1f39ee88d9f85278108c988/src/index.ts#L24) doesn't support variadic arguments that [$emits](https://vuejs.org/v2/api/#vm-emit) supports
2. mitt doesn't support `$once`

## Proposed Solution

I suggest to include [tiny-emitter](https://github.com/scottcorgan/tiny-emitter) which its interface is fully compatible with Vue 2 `$on`, `$off` and `$once`, and its [emit](https://github.com/scottcorgan/tiny-emitter/blob/4e6b2eb5869fb4ba862accaef7d16a7051349f4f/index.d.ts#L4) method do support variadic arguments. 

## Additional Information
Closes #493 