### PR TITLE
fix: `introduction.md`: `notable-new-features` anchor in TOC

### DIFF
--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -3,7 +3,7 @@
 This guide is primarily for users with prior Vue 2 experience who want to learn about the new features and changes in Vue 3. The lists may look long, but it is because we want to be as thorough as possible and provide detailed examples for every documented change. **This is not something you have to read from top to bottom before trying out Vue 3.**
 
 - [Quickstart](#quickstart)
-- [New Features](#new-features)
+- [Notable New Features](#notable-new-features)
 - [Breaking Changes](#breaking-changes)
 - [Supporting Libraries](#supporting-libraries)
 


### PR DESCRIPTION
## Description of Problem

The "New Features" TOC link in the Introduction section of the migration guide is broken, because the current name and anchor of the section (`New Features` and `new-features`, respectively) does not match the current section name and anchor (`Notable New Features` and `notable-new-features`, respectively).

## Proposed Solution

Fix the TOC item's title and link to match the new section name and anchor (`Notable New Features` and `notable-new-features`, respectively).

## Additional Information

The link seems to have been broken with commit 7e55600a84e37d6b26656e44394438d975ae4909 ([pretty GH view][pretty-view]).

[pretty-view]: 7e55600#diff-c9868b6bf75c863c7384dcf155eb6497R35