### PR TITLE
Remove duplicate words in Global API Treeshaking

### DIFF
--- a/src/guide/migration/global-api-treeshaking.md
+++ b/src/guide/migration/global-api-treeshaking.md
@@ -13,7 +13,7 @@ If you’ve ever had to manually manipulate DOM in Vue, you might have come acro
 import Vue from 'vue'
 
 Vue.nextTick(() => {
-  // something something DOM-related
+  // something DOM-related
 })
 ```
 
@@ -48,7 +48,7 @@ In Vue 3, the global and internal APIs have been restructured with tree-shaking 
 import { nextTick } from 'vue'
 
 nextTick(() => {
-  // something something DOM-related
+  // something DOM-related
 })
 ```
 


### PR DESCRIPTION
## Description of Problem

There are duplicate words (_something_) in **Global API Treeshaking** section of the docs.

## Proposed Solution

Remove duplicate words.

## Additional Information
