### PR TITLE
Fixes "Hook inside `setup`" grammar

### DIFF
--- a/src/guide/composition-api-lifecycle-hooks.md
+++ b/src/guide/composition-api-lifecycle-hooks.md
@@ -8,7 +8,7 @@ You can access a component's lifecycle hook by prefixing the lifecycle hook with
 
 The following table contains how the lifecycle hooks are invoked inside of [setup()](composition-api-setup.html):
 
-| Options API       | Hook inside inside `setup` |
+| Options API       | Hook inside `setup` |
 | ----------------- | -------------------------- |
 | `beforeCreate`    | Not needed\*               |
 | `created`         | Not needed\*               |


### PR DESCRIPTION
## Description of Problem
The column header for life-cycle hook equivalents in the setup context was called "Hook inside inside `setup`"

## Proposed Solution
One "inside" is enough.