### PR TITLE
fix: change to modern bundler

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -30,7 +30,7 @@ For production, we recommend linking to a specific version number and build to a
 
 ## NPM
 
-NPM is the recommended installation method when building large scale applications with Vue. It pairs nicely with module bundlers such as [Webpack](https://webpack.js.org/) or [Browserify](http://browserify.org/). Vue also provides accompanying tools for authoring [Single File Components](../guide/single-file-component.html).
+NPM is the recommended installation method when building large scale applications with Vue. It pairs nicely with module bundlers such as [Webpack](https://webpack.js.org/) or [Rollup](https://rollupjs.org/). Vue also provides accompanying tools for authoring [Single File Components](../guide/single-file-component.html).
 
 ```bash
 # latest stable


### PR DESCRIPTION
## Description of Problem
Browserify is currently almost underused in the Vue ecosystem.
In fact, it doesn't even work with [vueify](https://github.com/vuejs/vueify) in Vue 3.
vueify is arcvhied.

It has been arcvhied. 

## Proposed Solution
We recommend switching to the current mainstream bundler rollup
As Vue official, we offer a rollup-plugin-vue.
rollup-plugin-vue is available for Rollup as Vue official.
https://github.com/vuejs/rollup-plugin-vue

## Additional Information
