### PR TITLE
fix: the isAlgoliaSearch variable set to boolean type

### DIFF
--- a/src/.vuepress/theme/components/Navbar.vue
+++ b/src/.vuepress/theme/components/Navbar.vue
@@ -68,7 +68,7 @@ export default {
     },
 
     isAlgoliaSearch() {
-      return this.algolia && this.algolia.apiKey && this.algolia.indexName
+      return !!(this.algolia && this.algolia.apiKey && this.algolia.indexName)
     }
   },
 

--- a/src/.vuepress/theme/components/Navbar.vue
+++ b/src/.vuepress/theme/components/Navbar.vue
@@ -26,7 +26,7 @@
       <SearchBox
         v-if="
           isAlgoliaSearch === false &&
-            !(
+            (
               $site.themeConfig.search !== false &&
               $page.frontmatter.search !== false
             )


### PR DESCRIPTION
## Description of Problem
```js
  isAlgoliaSearch() {
      return this.algolia && this.algolia.apiKey && this.algolia.indexName // string type
    }
```

## Proposed Solution
```js
  isAlgoliaSearch() {
      return !!(this.algolia && this.algolia.apiKey && this.algolia.indexName) //  boolean type
    }
```

```js
  // config.js: disabled algolia
  algolia: {
      // indexName: 'vuejs-v3',
      // apiKey: 'bc6e8acb44ed4179c30d0a45d6140d3f'
    }
```

You should be able to use searchbox now, but origin code can't work, so change the condition.

```vue-html
    <SearchBox
        v-if="
          isAlgoliaSearch === false &&
            (
              $site.themeConfig.search !== false &&
              $page.frontmatter.search !== false
            )
        "
      />
```

## Additional Information

Use searchBox when disabled algoliaSearchBox.

it work:

![image](https://user-images.githubusercontent.com/8652596/93706380-4ca81880-fb58-11ea-9920-745d4cf606d1.png)

