### PR TITLE
fix: change "an matching id" to "a matching id"

### DIFF
--- a/src/guide/a11y-semantics.md
+++ b/src/guide/a11y-semantics.md
@@ -60,7 +60,7 @@ Though you might have seen labels wrapping the input fields like this:
 </label>
 ```
 
-Explicitly setting the labels with an matching id is better supported by assistive technology.
+Explicitly setting the labels with a matching id is better supported by assistive technology.
 :::
 
 #### aria-label


### PR DESCRIPTION
## Description of Problem
"setting the labels with an matching id" is incorrect.

## Proposed Solution
Change to "setting the labels with a matching id".