### PR TITLE
fix: update the API reference for inheritAttrs

### DIFF
--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -22,14 +22,13 @@
 
   By default, parent scope attribute bindings that are not recognized as props will "fallthrough". This means that when we have a single-root component, these bindings will be applied to the root element of the child component as normal HTML attributes. When authoring a component that wraps a target element or another component, this may not always be the desired behavior. By setting `inheritAttrs` to `false`, this default behavior can be disabled. The attributes are available via the `$attrs` instance property and can be explicitly bound to a non-root element using `v-bind`.
 
-  Note: this option does **not** affect `class` and `style` bindings.
-
 - **Usage:**
 
   ```js
   app.component('base-input', {
     inheritAttrs: false,
     props: ['label', 'value'],
+    emits: ['input'],
     template: `
       <label>
         {{ label }}


### PR DESCRIPTION
## Description of Problem

`inheritAttrs` has changed in Vue 3 and the current API reference entry is slightly incorrect.

1. The `class` and `style` are now included in `$attrs`, so they are affected by `inheritAttrs`.
2. The example given doesn't quite work. It emits the `input` event twice due to the listener in `$attrs`.

## Proposed Solution

1. Removed the note about `class` and `style`.
2. Added `emits` to the example, which fixes the double listeners.