### PR TITLE
fix: remove the restriction for name, which no longer applies

### DIFF
--- a/src/api/options-misc.md
+++ b/src/api/options-misc.md
@@ -4,8 +4,6 @@
 
 - **Type:** `string`
 
-- **Restriction:** only respected when used as a component option.
-
 - **Details:**
 
   Allow the component to recursively invoke itself in its template. Note that when a component is registered globally with `Vue.createApp({}).component({})`, the global ID is automatically set as its name.


### PR DESCRIPTION
## Description of Problem

For the `name` option, I don't think this line still applies in Vue 3:

> **Restriction:** only respected when used as a component option.

The distinction between component options and root instance options no longer exists. We now only have component options.

If you're curious, here's a demo showing `name` working fine on the root component: https://jsfiddle.net/skirtle/7ocdjz65/

## Proposed Solution

Remove that line.