### PR TITLE
fix typo: instect -> inspect

### DIFF
--- a/src/guide/a11y-semantics.md
+++ b/src/guide/a11y-semantics.md
@@ -159,7 +159,7 @@ Using [`aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibi
 </p>
 <script async src="https://static.codepen.io/assets/embed/ei.js"></script>
 
-You can see the description by instecting Chrome DevTools:
+You can see the description by inspecting Chrome DevTools:
 
 ![Chrome Developer Tools showing input accessible name from aria-labelledby and description with aria-describedby](/images/AccessibleARIAdescribedby.png)
 


### PR DESCRIPTION
## Description of Problem
The word `instecting` is typo.
`You can see the description by instecting Chrome DevTools:`

https://v3.vuejs.org/guide/a11y-semantics.html#instructions
Labels > aria-describedby
## Proposed Solution
change to `inspecting` from `instecting`.

## Additional Information
