### PR TITLE
fix: improve component attrs section

### DIFF
--- a/src/guide/component-attrs.md
+++ b/src/guide/component-attrs.md
@@ -2,7 +2,7 @@
 
 > This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
-A component non-prop attribute is an attribute or event listener that is passed to a component, but does not have a corresponding property defined in [props](component-props) or [emits](component-custom-events.html#defining-custom-events). Common examples of this include `class`, `style`, and `id` attributes.
+A component non-prop attribute is an attribute or event listener that is passed to a component, but does not have a corresponding property defined in [props](component-props) or [emits](component-custom-events.html#defining-custom-events). Common examples of this include `class`, `style`, and `id` attributes. You can access those attributes via `$attrs` property.
 
 ## Attribute Inheritance
 
@@ -82,7 +82,7 @@ If you do **not** want a component to automatically inherit attributes, you can 
 
 The common scenario for disabling an attribute inheritance is when attributes need to be applied to other elements besides the root node.
 
-By setting the `inheritAttrs` option to `false`, this gives you access to the component's `$attrs` property, which includes all attributes not included to component `props` and `emits` properties (e.g., `class`, `style`, `v-on` listeners, etc.).
+By setting the `inheritAttrs` option to `false`, you can control to apply to other elements attributes to use the component's `$attrs` property, which includes all attributes not included to component `props` and `emits` properties (e.g., `class`, `style`, `v-on` listeners, etc.).
 
 Using our date-picker component example from the [previous section]('#attribute-inheritance), in the event we need to apply all non-prop attributes to the `input` element rather than the root `div` element, this can be accomplished by using the `v-bind` shortcut.
 


### PR DESCRIPTION
## Description of Problem
The documentation says that `$attrs` can be accessed by setting `inheritAttrs: false`.
However, `$attrs` can be accessed with or without `inheritAttrs` setting.

The rfcs says the following:

>this.$attrs (and context.attrs for setup() and functional components) now contains all attributes passed to the component (as long as it is not declared as props). 

https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md#inheritattrs-false

## Proposed Solution
Remove the following sentence and add the new sentence of this PR, or we change to another explanation.

## Additional Information
I hope that you update my docs is wrote with my poor English! 🙇 