### PR TITLE
docs: Add migration guide for `h` rendering registered component (#1927)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,11987 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/cache-browser-local-storage/download/@algolia/cache-browser-local-storage-4.5.1.tgz",
+      "integrity": "sha1-vfWMMHlWg/1IMQxVLDoQ8Q+ybis=",
+      "requires": {
+        "@algolia/cache-common": "4.5.1"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/cache-common/download/@algolia/cache-common-4.5.1.tgz",
+      "integrity": "sha1-Ou/aM4LcMLZwkbAaPXRh2TcIKCE="
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/cache-in-memory/download/@algolia/cache-in-memory-4.5.1.tgz",
+      "integrity": "sha1-EnzUc0dPYjAKFX9O47P2g2ADzzU=",
+      "requires": {
+        "@algolia/cache-common": "4.5.1"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/client-account/download/@algolia/client-account-4.5.1.tgz",
+      "integrity": "sha1-fTzNoJ08eEmxcckV2ggz52SbqzM=",
+      "requires": {
+        "@algolia/client-common": "4.5.1",
+        "@algolia/client-search": "4.5.1",
+        "@algolia/transporter": "4.5.1"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/client-analytics/download/@algolia/client-analytics-4.5.1.tgz",
+      "integrity": "sha1-v8KnKSqep4nKPJn3mx+WwI03iCg=",
+      "requires": {
+        "@algolia/client-common": "4.5.1",
+        "@algolia/client-search": "4.5.1",
+        "@algolia/requester-common": "4.5.1",
+        "@algolia/transporter": "4.5.1"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/client-common/download/@algolia/client-common-4.5.1.tgz",
+      "integrity": "sha1-kaQB66bq/XzHSgrsy0xubLHnICY=",
+      "requires": {
+        "@algolia/requester-common": "4.5.1",
+        "@algolia/transporter": "4.5.1"
+      }
+    },
+    "@algolia/client-recommendation": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/client-recommendation/download/@algolia/client-recommendation-4.5.1.tgz",
+      "integrity": "sha1-V6H+MJh8kLENURm459bNkcQj5Uw=",
+      "requires": {
+        "@algolia/client-common": "4.5.1",
+        "@algolia/requester-common": "4.5.1",
+        "@algolia/transporter": "4.5.1"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/client-search/download/@algolia/client-search-4.5.1.tgz",
+      "integrity": "sha1-y3mMmdZiHimjYzS5IgVRinTs3z4=",
+      "requires": {
+        "@algolia/client-common": "4.5.1",
+        "@algolia/requester-common": "4.5.1",
+        "@algolia/transporter": "4.5.1"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/logger-common/download/@algolia/logger-common-4.5.1.tgz",
+      "integrity": "sha1-GNZUUWNpoo4lrX7uT8KIL9R+2Ow="
+    },
+    "@algolia/logger-console": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/logger-console/download/@algolia/logger-console-4.5.1.tgz",
+      "integrity": "sha1-yd75fCC+pe7LSwf40/czwBktF2E=",
+      "requires": {
+        "@algolia/logger-common": "4.5.1"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/requester-browser-xhr/download/@algolia/requester-browser-xhr-4.5.1.tgz",
+      "integrity": "sha1-g4tVIJ0sg1ct8mEzj3zXW+Nt5AE=",
+      "requires": {
+        "@algolia/requester-common": "4.5.1"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/requester-common/download/@algolia/requester-common-4.5.1.tgz",
+      "integrity": "sha1-o00C2qYJPhErUo07zVpUZ8ALqCM="
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/requester-node-http/download/@algolia/requester-node-http-4.5.1.tgz",
+      "integrity": "sha1-KZEcEExnFKXLKdOZHytQxSMB4JE=",
+      "requires": {
+        "@algolia/requester-common": "4.5.1"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@algolia/transporter/download/@algolia/transporter-4.5.1.tgz",
+      "integrity": "sha1-4KXGTzWLZ1H4ZwAfUfOE1vx+3hQ=",
+      "requires": {
+        "@algolia/cache-common": "4.5.1",
+        "@algolia/logger-common": "4.5.1",
+        "@algolia/requester-common": "4.5.1"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/code-frame/download/@babel/code-frame-7.10.4.tgz",
+      "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/compat-data/download/@babel/compat-data-7.11.0.tgz",
+      "integrity": "sha1-6fc+/gmvE1W3I6fzmxG61jfXyZw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.12.0",
+        "invariant": "^2.2.4",
+        "semver": "^5.5.0"
+      }
+    },
+    "@babel/core": {
+      "version": "7.11.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/core/download/@babel/core-7.11.6.tgz",
+      "integrity": "sha1-OpRV3HOH/xusRXcGULwTugShVlE=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.6",
+        "@babel/helper-module-transforms": "^7.11.0",
+        "@babel/helpers": "^7.10.4",
+        "@babel/parser": "^7.11.5",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.11.5",
+        "@babel/types": "^7.11.5",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.19",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-4.2.0.tgz",
+          "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json5/download/json5-2.1.3.tgz",
+          "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.11.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/generator/download/@babel/generator-7.11.6.tgz",
+      "integrity": "sha1-uGiQD4GxY7TUZOokVFxhy6xNxiA=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.5",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-annotate-as-pure/download/@babel/helper-annotate-as-pure-7.10.4.tgz",
+      "integrity": "sha1-W/DUlaP3V6w72ki1vzs7ownHK6M=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-builder-binary-assignment-operator-visitor/download/@babel/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+      "integrity": "sha1-uwt18xv5jL+f8UPBrleLhydK4aM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-compilation-targets/download/@babel/helper-compilation-targets-7.10.4.tgz",
+      "integrity": "sha1-gEro4/BDdmB8x5G51H1UAnYzK9I=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.10.4",
+        "browserslist": "^4.12.0",
+        "invariant": "^2.2.4",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-create-class-features-plugin/download/@babel/helper-create-class-features-plugin-7.10.5.tgz",
+      "integrity": "sha1-n2FEa6gOgkCwpchcb9rIRZ1vJZ0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-member-expression-to-functions": "^7.10.5",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-create-regexp-features-plugin/download/@babel/helper-create-regexp-features-plugin-7.10.4.tgz",
+      "integrity": "sha1-/dYNiFJGWaC2lZwFeZJeQlcU87g=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-regex": "^7.10.4",
+        "regexpu-core": "^4.7.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-define-map/download/@babel/helper-define-map-7.10.5.tgz",
+      "integrity": "sha1-tTwQ23imQIABUmkrEzkxR6y5uzA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/types": "^7.10.5",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.11.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-explode-assignable-expression/download/@babel/helper-explode-assignable-expression-7.11.4.tgz",
+      "integrity": "sha1-LY40cCUswXq6kX7eeAPUp6J2pBs=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-function-name/download/@babel/helper-function-name-7.10.4.tgz",
+      "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-get-function-arity/download/@babel/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-hoist-variables/download/@babel/helper-hoist-variables-7.10.4.tgz",
+      "integrity": "sha1-1JsAHR1aaMpeZgTdoBpil/fJOB4=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-member-expression-to-functions/download/@babel/helper-member-expression-to-functions-7.11.0.tgz",
+      "integrity": "sha1-rmnIPYTugvS0L5bioJQQk1qPJt8=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-module-imports/download/@babel/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha1-TFxUvgS9MWcKc4J5fXW5+i5bViA=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-module-transforms/download/@babel/helper-module-transforms-7.11.0.tgz",
+      "integrity": "sha1-sW8lAinkchGr3YSzS2RzfCqy01k=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.11.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-optimise-call-expression/download/@babel/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha1-UNyWQT1ZT5lad5BZBbBYk813lnM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-plugin-utils/download/@babel/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha1-L3WoMSadT2d95JmG3/WZJ1M883U=",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-regex/download/@babel/helper-regex-7.10.5.tgz",
+      "integrity": "sha1-Mt+7eYmQc8QVVXBToZvQVarlCuA=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.11.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-remap-async-to-generator/download/@babel/helper-remap-async-to-generator-7.11.4.tgz",
+      "integrity": "sha1-RHTqn3Q48YV14wsMrHhARbQCoS0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-wrap-function": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-replace-supers/download/@babel/helper-replace-supers-7.10.4.tgz",
+      "integrity": "sha1-1YXNk4jqBuYDHkzUS2cTy+rZ5s8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-simple-access/download/@babel/helper-simple-access-7.10.4.tgz",
+      "integrity": "sha1-D1zNopRSd6KnotOoIeFTle3PNGE=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-skip-transparent-expression-wrappers/download/@babel/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+      "integrity": "sha1-7sFi8RLC9Y068K8SXju1dmUUZyk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-split-export-declaration/download/@babel/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha1-+KSRJErPamdhWKxCBykRuoOtCZ8=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-validator-identifier/download/@babel/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
+      "dev": true
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helper-wrap-function/download/@babel/helper-wrap-function-7.10.4.tgz",
+      "integrity": "sha1-im9wHqsP8592W1oc/vQJmQ5iS4c=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/helpers/download/@babel/helpers-7.10.4.tgz",
+      "integrity": "sha1-Kr6w1yGv98Cpc3a54fb2XXpHUEQ=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/highlight/download/@babel/highlight-7.10.4.tgz",
+      "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.11.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/parser/download/@babel/parser-7.11.5.tgz",
+      "integrity": "sha1-x/9jA99xCA7HpPW4wAPFjxz1EDc=",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-async-generator-functions/download/@babel/plugin-proposal-async-generator-functions-7.10.5.tgz",
+      "integrity": "sha1-NJHKvy98F5q4IGBs7Cf+0V4OhVg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.10.4",
+        "@babel/plugin-syntax-async-generators": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-class-properties/download/@babel/plugin-proposal-class-properties-7.10.4.tgz",
+      "integrity": "sha1-ozv2Mto5ClnHqMVwBF0RFc13iAc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-decorators/download/@babel/plugin-proposal-decorators-7.10.5.tgz",
+      "integrity": "sha1-QomLukeLxLGuJCpwOpU6etNQ/7Q=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-decorators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-dynamic-import/download/@babel/plugin-proposal-dynamic-import-7.10.4.tgz",
+      "integrity": "sha1-uleibLmLN3QenVvKG4sN34KR8X4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-export-namespace-from": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-export-namespace-from/download/@babel/plugin-proposal-export-namespace-from-7.10.4.tgz",
+      "integrity": "sha1-Vw2IO5EDFjez4pWO6jxDjmLAX1Q=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-json-strings/download/@babel/plugin-proposal-json-strings-7.10.4.tgz",
+      "integrity": "sha1-WT5ZxjUoFgIzvTIbGuvgggwjQds=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-logical-assignment-operators": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-logical-assignment-operators/download/@babel/plugin-proposal-logical-assignment-operators-7.11.0.tgz",
+      "integrity": "sha1-n4DkgsAwg8hxJd7hACa1hSfqIMg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-nullish-coalescing-operator/download/@babel/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
+      "integrity": "sha1-AqfpYfwy5tWy2wZJ4Bv4Dd7n4Eo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-numeric-separator/download/@babel/plugin-proposal-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-zhWQ/wplrRKXCmCdeIVemkwa7wY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-object-rest-spread/download/@babel/plugin-proposal-object-rest-spread-7.11.0.tgz",
+      "integrity": "sha1-vYH5Wh90Z2DqQ7bC09YrEXkK0K8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-transform-parameters": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-optional-catch-binding/download/@babel/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+      "integrity": "sha1-Mck4MJ0kp4pJ1o/av/qoY3WFVN0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-optional-chaining/download/@babel/plugin-proposal-optional-chaining-7.11.0.tgz",
+      "integrity": "sha1-3lhm0GRvav2quKVmOC/joiF1UHY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-private-methods": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-private-methods/download/@babel/plugin-proposal-private-methods-7.10.4.tgz",
+      "integrity": "sha1-sWDZcrj9ulx9ERoUX8jEIfwqaQk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-proposal-unicode-property-regex/download/@babel/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+      "integrity": "sha1-RIPNpTBBzjQTt/4vAAImZd36p10=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-async-generators/download/@babel/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-class-properties/download/@babel/plugin-syntax-class-properties-7.10.4.tgz",
+      "integrity": "sha1-ZkTmoLqlWmH54yMfbJ7rbuRsEkw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-decorators/download/@babel/plugin-syntax-decorators-7.10.4.tgz",
+      "integrity": "sha1-aFMIWyxCn50yLQL1pjUBjN6yNgw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-dynamic-import/download/@babel/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-namespace-from": {
+      "version": "7.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-export-namespace-from/download/@babel/plugin-syntax-export-namespace-from-7.8.3.tgz",
+      "integrity": "sha1-AolkqbqA28CUyRXEh618TnpmRlo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-json-strings/download/@babel/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-jsx/download/@babel/plugin-syntax-jsx-7.10.4.tgz",
+      "integrity": "sha1-Oauq48v3EMQ3PYQpSE5rohNAFmw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-logical-assignment-operators/download/@babel/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha1-ypHvRjA1MESLkGZSusLp/plB9pk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-nullish-coalescing-operator/download/@babel/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-numeric-separator/download/@babel/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha1-ubBws+M1cM2f0Hun+pHA3Te5r5c=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-object-rest-spread/download/@babel/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-optional-catch-binding/download/@babel/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-optional-chaining/download/@babel/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-syntax-top-level-await/download/@babel/plugin-syntax-top-level-await-7.10.4.tgz",
+      "integrity": "sha1-S764kXtU/PdoNk4KgfVg4zo+9X0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-arrow-functions/download/@babel/plugin-transform-arrow-functions-7.10.4.tgz",
+      "integrity": "sha1-4ilg135pfHT0HFAdRNc9v4pqZM0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-async-to-generator/download/@babel/plugin-transform-async-to-generator-7.10.4.tgz",
+      "integrity": "sha1-QaUBfknrbzzak5KlHu8pQFskWjc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-block-scoped-functions/download/@babel/plugin-transform-block-scoped-functions-7.10.4.tgz",
+      "integrity": "sha1-GvpZV0T3XkOpGvc7DZmOz+Trwug=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.11.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-block-scoping/download/@babel/plugin-transform-block-scoping-7.11.1.tgz",
+      "integrity": "sha1-W37+mIUr741lLAsoFEzZOp5LUhU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-classes/download/@babel/plugin-transform-classes-7.10.4.tgz",
+      "integrity": "sha1-QFE2rys+IYvEoZJiKLyRerGgrcc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-define-map": "^7.10.4",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-computed-properties/download/@babel/plugin-transform-computed-properties-7.10.4.tgz",
+      "integrity": "sha1-ne2DqBboLe0o1S1LTsvdgQzfwOs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-destructuring/download/@babel/plugin-transform-destructuring-7.10.4.tgz",
+      "integrity": "sha1-cN3Ss9G+qD0BUJ6bsl3bOnT8heU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-dotall-regex/download/@babel/plugin-transform-dotall-regex-7.10.4.tgz",
+      "integrity": "sha1-RpwgYhBcHragQOr0+sS0iAeDle4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-duplicate-keys/download/@babel/plugin-transform-duplicate-keys-7.10.4.tgz",
+      "integrity": "sha1-aX5Qyf7hQ4D+hD0fMGspVhdDHkc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-exponentiation-operator/download/@babel/plugin-transform-exponentiation-operator-7.10.4.tgz",
+      "integrity": "sha1-WuM4xX+M9AAb2zVgeuZrktZlry4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-for-of/download/@babel/plugin-transform-for-of-7.10.4.tgz",
+      "integrity": "sha1-wIiS6IGdOl2ykDGxFa9RHbv+uuk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-function-name/download/@babel/plugin-transform-function-name-7.10.4.tgz",
+      "integrity": "sha1-akZ4gOD8ljhRS6NpERgR3b4mRLc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-literals/download/@babel/plugin-transform-literals-7.10.4.tgz",
+      "integrity": "sha1-n0K6CEEQChNfInEtDjkcRi9XHzw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-member-expression-literals/download/@babel/plugin-transform-member-expression-literals-7.10.4.tgz",
+      "integrity": "sha1-sexE/PGVr8uNssYs2OVRyIG6+Lc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-modules-amd/download/@babel/plugin-transform-modules-amd-7.10.5.tgz",
+      "integrity": "sha1-G5zdrwXZ6Is6rTOcs+RFxPAgqbE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-modules-commonjs/download/@babel/plugin-transform-modules-commonjs-7.10.4.tgz",
+      "integrity": "sha1-ZmZ8Pu2h6/eJbUHx8WsXEFovvKA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-modules-systemjs/download/@babel/plugin-transform-modules-systemjs-7.10.5.tgz",
+      "integrity": "sha1-YnAJnIVAZmgbrp4F+H4bnK2+jIU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-modules-umd/download/@babel/plugin-transform-modules-umd-7.10.4.tgz",
+      "integrity": "sha1-moSB/oG4JGVLOgtl2j34nz0hg54=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/download/@babel/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+      "integrity": "sha1-eLTZeIELbzvPA/njGPL8DtQa7LY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-new-target/download/@babel/plugin-transform-new-target-7.10.4.tgz",
+      "integrity": "sha1-kJfXU8t7Aky3OBo7LlLpUTqcaIg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-object-super/download/@babel/plugin-transform-object-super-7.10.4.tgz",
+      "integrity": "sha1-1xRsTROUM+emUm+IjGZ+MUoJOJQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-parameters/download/@babel/plugin-transform-parameters-7.10.5.tgz",
+      "integrity": "sha1-WdM51Y0LGVBDX0BD504lEABeLEo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-property-literals/download/@babel/plugin-transform-property-literals-7.10.4.tgz",
+      "integrity": "sha1-9v5UtlkDUimHhbg+3YFdIUxC48A=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-regenerator/download/@babel/plugin-transform-regenerator-7.10.4.tgz",
+      "integrity": "sha1-IBXlnYOQdOdoON4hWdtCGWb9i2M=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-reserved-words/download/@babel/plugin-transform-reserved-words-7.10.4.tgz",
+      "integrity": "sha1-jyaCvNzvntMn4bCGFYXXAT+KVN0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.11.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-runtime/download/@babel/plugin-transform-runtime-7.11.5.tgz",
+      "integrity": "sha1-8Qi8jgzzPDfaAxwJfR30cLOik/w=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-shorthand-properties/download/@babel/plugin-transform-shorthand-properties-7.10.4.tgz",
+      "integrity": "sha1-n9Jexc3VVbt/Rz5ebuHJce7eTdY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-spread/download/@babel/plugin-transform-spread-7.11.0.tgz",
+      "integrity": "sha1-+oTTAPXk9XdS/kGm0bPFVPE/F8w=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-sticky-regex/download/@babel/plugin-transform-sticky-regex-7.10.4.tgz",
+      "integrity": "sha1-jziJ7oZXWBEwop2cyR18c7fEoo0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-regex": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.10.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-template-literals/download/@babel/plugin-transform-template-literals-7.10.5.tgz",
+      "integrity": "sha1-eLxdYmpmQtszEtnQ8AH152Of3ow=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-typeof-symbol/download/@babel/plugin-transform-typeof-symbol-7.10.4.tgz",
+      "integrity": "sha1-lQnxp+7DHE7b/+E3wWzDP/C8W/w=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-unicode-escapes": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-unicode-escapes/download/@babel/plugin-transform-unicode-escapes-7.10.4.tgz",
+      "integrity": "sha1-/q5SM5HHZR3awRXa4KnQaFeJIAc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/plugin-transform-unicode-regex/download/@babel/plugin-transform-unicode-regex-7.10.4.tgz",
+      "integrity": "sha1-5W1x+SgvrG2wnIJ0IFVXbV5tgKg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.11.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/preset-env/download/@babel/preset-env-7.11.5.tgz",
+      "integrity": "sha1-GMtLk3nj6S/+qSwHRxqZopFOQnI=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.11.0",
+        "@babel/helper-compilation-targets": "^7.10.4",
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
+        "@babel/plugin-proposal-class-properties": "^7.10.4",
+        "@babel/plugin-proposal-dynamic-import": "^7.10.4",
+        "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
+        "@babel/plugin-proposal-json-strings": "^7.10.4",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
+        "@babel/plugin-proposal-numeric-separator": "^7.10.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
+        "@babel/plugin-proposal-optional-chaining": "^7.11.0",
+        "@babel/plugin-proposal-private-methods": "^7.10.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-class-properties": "^7.10.4",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-top-level-await": "^7.10.4",
+        "@babel/plugin-transform-arrow-functions": "^7.10.4",
+        "@babel/plugin-transform-async-to-generator": "^7.10.4",
+        "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
+        "@babel/plugin-transform-block-scoping": "^7.10.4",
+        "@babel/plugin-transform-classes": "^7.10.4",
+        "@babel/plugin-transform-computed-properties": "^7.10.4",
+        "@babel/plugin-transform-destructuring": "^7.10.4",
+        "@babel/plugin-transform-dotall-regex": "^7.10.4",
+        "@babel/plugin-transform-duplicate-keys": "^7.10.4",
+        "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
+        "@babel/plugin-transform-for-of": "^7.10.4",
+        "@babel/plugin-transform-function-name": "^7.10.4",
+        "@babel/plugin-transform-literals": "^7.10.4",
+        "@babel/plugin-transform-member-expression-literals": "^7.10.4",
+        "@babel/plugin-transform-modules-amd": "^7.10.4",
+        "@babel/plugin-transform-modules-commonjs": "^7.10.4",
+        "@babel/plugin-transform-modules-systemjs": "^7.10.4",
+        "@babel/plugin-transform-modules-umd": "^7.10.4",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
+        "@babel/plugin-transform-new-target": "^7.10.4",
+        "@babel/plugin-transform-object-super": "^7.10.4",
+        "@babel/plugin-transform-parameters": "^7.10.4",
+        "@babel/plugin-transform-property-literals": "^7.10.4",
+        "@babel/plugin-transform-regenerator": "^7.10.4",
+        "@babel/plugin-transform-reserved-words": "^7.10.4",
+        "@babel/plugin-transform-shorthand-properties": "^7.10.4",
+        "@babel/plugin-transform-spread": "^7.11.0",
+        "@babel/plugin-transform-sticky-regex": "^7.10.4",
+        "@babel/plugin-transform-template-literals": "^7.10.4",
+        "@babel/plugin-transform-typeof-symbol": "^7.10.4",
+        "@babel/plugin-transform-unicode-escapes": "^7.10.4",
+        "@babel/plugin-transform-unicode-regex": "^7.10.4",
+        "@babel/preset-modules": "^0.1.3",
+        "@babel/types": "^7.11.5",
+        "browserslist": "^4.12.0",
+        "core-js-compat": "^3.6.2",
+        "invariant": "^2.2.2",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/preset-modules/download/@babel/preset-modules-0.1.4.tgz",
+      "integrity": "sha1-Ni8raMZihClw/bXiVP/I/BwuQV4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.11.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/runtime/download/@babel/runtime-7.11.2.tgz",
+      "integrity": "sha1-9UnBPHVMxAuHZEufqfCaapX+BzY=",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.10.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/template/download/@babel/template-7.10.4.tgz",
+      "integrity": "sha1-MlGZbEIA68cdGo/EBfupQPNrong=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.11.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/traverse/download/@babel/traverse-7.11.5.tgz",
+      "integrity": "sha1-vnd7k7UY62127i4eodFD2qEeYcM=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.11.5",
+        "@babel/types": "^7.11.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-4.2.0.tgz",
+          "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.11.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@babel/types/download/@babel/types-7.11.5.tgz",
+      "integrity": "sha1-2d5XfQElLXfGgAzuA57mT691Zi0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@docsearch/css": {
+      "version": "1.0.0-alpha.28",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@docsearch/css/download/@docsearch/css-1.0.0-alpha.28.tgz",
+      "integrity": "sha1-yKLNjBuzpoVcUYkunb2rXUL+biM="
+    },
+    "@docsearch/js": {
+      "version": "1.0.0-alpha.28",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@docsearch/js/download/@docsearch/js-1.0.0-alpha.28.tgz",
+      "integrity": "sha1-8P3nuKax4dinrh52VcQ9lZtFeys=",
+      "requires": {
+        "@docsearch/react": "^1.0.0-alpha.28",
+        "preact": "^10.0.0"
+      }
+    },
+    "@docsearch/react": {
+      "version": "1.0.0-alpha.28",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@docsearch/react/download/@docsearch/react-1.0.0-alpha.28.tgz",
+      "integrity": "sha1-TwOe15+LMzKxmldneyGa68UBDp0=",
+      "requires": {
+        "@docsearch/css": "^1.0.0-alpha.28",
+        "@francoischalifour/autocomplete-core": "^1.0.0-alpha.28",
+        "@francoischalifour/autocomplete-preset-algolia": "^1.0.0-alpha.28",
+        "algoliasearch": "^4.0.0"
+      }
+    },
+    "@francoischalifour/autocomplete-core": {
+      "version": "1.0.0-alpha.28",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@francoischalifour/autocomplete-core/download/@francoischalifour/autocomplete-core-1.0.0-alpha.28.tgz",
+      "integrity": "sha1-a52EkSiOd/gx6bNF1GFiOw0/UAU="
+    },
+    "@francoischalifour/autocomplete-preset-algolia": {
+      "version": "1.0.0-alpha.28",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@francoischalifour/autocomplete-preset-algolia/download/@francoischalifour/autocomplete-preset-algolia-1.0.0-alpha.28.tgz",
+      "integrity": "sha1-pa15lvQuQ+Ssu04AENZjdG0OmZc="
+    },
+    "@mrmlnc/readdir-enhanced": {
+      "version": "2.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@mrmlnc/readdir-enhanced/download/@mrmlnc/readdir-enhanced-2.2.1.tgz",
+      "integrity": "sha1-UkryQNGjYFJ7cwR17PoTRKpUDd4=",
+      "dev": true,
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "glob-to-regexp": "^0.3.0"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@nodelib/fs.stat/download/@nodelib/fs.stat-1.1.3.tgz",
+      "integrity": "sha1-K1o6s/kYzKSKjHVMCBaOPwPrphs=",
+      "dev": true
+    },
+    "@sindresorhus/is": {
+      "version": "0.14.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@sindresorhus/is/download/@sindresorhus/is-0.14.0.tgz",
+      "integrity": "sha1-n7OjzzEyMoFR81PeRjLgHlIQK+o=",
+      "dev": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@szmarczak/http-timer/download/@szmarczak/http-timer-1.1.2.tgz",
+      "integrity": "sha1-sWZeLEYaLNkvTBu/UNVFTeDUtCE=",
+      "dev": true,
+      "requires": {
+        "defer-to-connect": "^1.0.1"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@types/color-name/download/@types/color-name-1.1.1.tgz",
+      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@types/glob/download/@types/glob-7.1.3.tgz",
+      "integrity": "sha1-5rqA82t9qtLGhazZJmOC5omFwYM=",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@types/json-schema/download/@types/json-schema-7.0.6.tgz",
+      "integrity": "sha1-9MfsQ+gbMZqYFRFQMXCfJph4kfA=",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@types/minimatch/download/@types/minimatch-3.0.3.tgz",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.11.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@types/node/download/@types/node-14.11.2.tgz",
+      "integrity": "sha1-LeHtZnBDk4faHJ9UmireKwp5klY=",
+      "dev": true
+    },
+    "@types/q": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@types/q/download/@types/q-1.5.4.tgz",
+      "integrity": "sha1-FZJUFOCtLNdlv+9YhC9+JqesyyQ=",
+      "dev": true
+    },
+    "@vue/babel-helper-vue-jsx-merge-props": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-helper-vue-jsx-merge-props/download/@vue/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
+      "integrity": "sha1-BI/leZWNpAj7eosqPsBQtQpmEEA=",
+      "dev": true
+    },
+    "@vue/babel-helper-vue-transform-on": {
+      "version": "1.0.0-rc.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-helper-vue-transform-on/download/@vue/babel-helper-vue-transform-on-1.0.0-rc.2.tgz",
+      "integrity": "sha1-ckY0H2ZufG5lsT2kIOLOhXFPu8o=",
+      "dev": true
+    },
+    "@vue/babel-plugin-jsx": {
+      "version": "1.0.0-rc.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-plugin-jsx/download/@vue/babel-plugin-jsx-1.0.0-rc.3.tgz",
+      "integrity": "sha1-q0d+6Vx2T75ohCou3dR08SLnCsY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "@vue/babel-helper-vue-transform-on": "^1.0.0-rc.2",
+        "camelcase": "^6.0.0",
+        "html-tags": "^3.1.0",
+        "svg-tags": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/camelcase/download/camelcase-6.0.0.tgz",
+          "integrity": "sha1-Uln3ww414njxvcKk2RIws3ytmB4=",
+          "dev": true
+        }
+      }
+    },
+    "@vue/babel-plugin-transform-vue-jsx": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-plugin-transform-vue-jsx/download/@vue/babel-plugin-transform-vue-jsx-1.1.2.tgz",
+      "integrity": "sha1-wKPm78Ai515CR7RIqPxrhvA+kcA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+        "html-tags": "^2.0.0",
+        "lodash.kebabcase": "^4.1.1",
+        "svg-tags": "^1.0.0"
+      },
+      "dependencies": {
+        "html-tags": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/html-tags/download/html-tags-2.0.0.tgz",
+          "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+          "dev": true
+        }
+      }
+    },
+    "@vue/babel-preset-app": {
+      "version": "4.5.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-preset-app/download/@vue/babel-preset-app-4.5.6.tgz",
+      "integrity": "sha1-OR24NRh5DAfyQcpSrJfGpxvZ2FE=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.0",
+        "@babel/helper-compilation-targets": "^7.9.6",
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/plugin-proposal-class-properties": "^7.8.3",
+        "@babel/plugin-proposal-decorators": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-syntax-jsx": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.11.0",
+        "@babel/preset-env": "^7.11.0",
+        "@babel/runtime": "^7.11.0",
+        "@vue/babel-plugin-jsx": "^1.0.0-0",
+        "@vue/babel-preset-jsx": "^1.1.2",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "core-js": "^3.6.5",
+        "core-js-compat": "^3.6.5",
+        "semver": "^6.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "@vue/babel-preset-jsx": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-preset-jsx/download/@vue/babel-preset-jsx-1.1.2.tgz",
+      "integrity": "sha1-LhaetMIE6jfKZsLqhaiAv8mdTyA=",
+      "dev": true,
+      "requires": {
+        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
+        "@vue/babel-sugar-functional-vue": "^1.1.2",
+        "@vue/babel-sugar-inject-h": "^1.1.2",
+        "@vue/babel-sugar-v-model": "^1.1.2",
+        "@vue/babel-sugar-v-on": "^1.1.2"
+      }
+    },
+    "@vue/babel-sugar-functional-vue": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-sugar-functional-vue/download/@vue/babel-sugar-functional-vue-1.1.2.tgz",
+      "integrity": "sha1-9+JPugnm8e5wEEVgqICAV1VfGpo=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@vue/babel-sugar-inject-h": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-sugar-inject-h/download/@vue/babel-sugar-inject-h-1.1.2.tgz",
+      "integrity": "sha1-ilJ2ttji7Rb/yAeKrZQjYnTm7fA=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
+    "@vue/babel-sugar-v-model": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-sugar-v-model/download/@vue/babel-sugar-v-model-1.1.2.tgz",
+      "integrity": "sha1-H/b9G4ACI/ycsehNzrXlLXN6gZI=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
+        "camelcase": "^5.0.0",
+        "html-tags": "^2.0.0",
+        "svg-tags": "^1.0.0"
+      },
+      "dependencies": {
+        "html-tags": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/html-tags/download/html-tags-2.0.0.tgz",
+          "integrity": "sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=",
+          "dev": true
+        }
+      }
+    },
+    "@vue/babel-sugar-v-on": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/babel-sugar-v-on/download/@vue/babel-sugar-v-on-1.1.2.tgz",
+      "integrity": "sha1-su+ZuPL6sJ++rSWq1w70Lhz1sTs=",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-jsx": "^7.2.0",
+        "@vue/babel-plugin-transform-vue-jsx": "^1.1.2",
+        "camelcase": "^5.0.0"
+      }
+    },
+    "@vue/component-compiler-utils": {
+      "version": "3.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vue/component-compiler-utils/download/@vue/component-compiler-utils-3.2.0.tgz",
+      "integrity": "sha1-j4UYLO7Sjps8dTE95mn4MWbRHl0=",
+      "dev": true,
+      "requires": {
+        "consolidate": "^0.15.1",
+        "hash-sum": "^1.0.2",
+        "lru-cache": "^4.1.2",
+        "merge-source-map": "^1.1.0",
+        "postcss": "^7.0.14",
+        "postcss-selector-parser": "^6.0.2",
+        "prettier": "^1.18.2",
+        "source-map": "~0.6.1",
+        "vue-template-es2015-compiler": "^1.9.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@vuepress/core": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/core/download/@vuepress/core-1.5.4.tgz",
+      "integrity": "sha1-A20o1syKCSiRMRbeXr6AsLSprBs=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.8.4",
+        "@vue/babel-preset-app": "^4.1.2",
+        "@vuepress/markdown": "1.5.4",
+        "@vuepress/markdown-loader": "1.5.4",
+        "@vuepress/plugin-last-updated": "1.5.4",
+        "@vuepress/plugin-register-components": "1.5.4",
+        "@vuepress/shared-utils": "1.5.4",
+        "autoprefixer": "^9.5.1",
+        "babel-loader": "^8.0.4",
+        "cache-loader": "^3.0.0",
+        "chokidar": "^2.0.3",
+        "connect-history-api-fallback": "^1.5.0",
+        "copy-webpack-plugin": "^5.0.2",
+        "core-js": "^3.6.4",
+        "cross-spawn": "^6.0.5",
+        "css-loader": "^2.1.1",
+        "file-loader": "^3.0.1",
+        "js-yaml": "^3.13.1",
+        "lru-cache": "^5.1.1",
+        "mini-css-extract-plugin": "0.6.0",
+        "optimize-css-assets-webpack-plugin": "^5.0.1",
+        "portfinder": "^1.0.13",
+        "postcss-loader": "^3.0.0",
+        "postcss-safe-parser": "^4.0.1",
+        "toml": "^3.0.0",
+        "url-loader": "^1.0.1",
+        "vue": "^2.6.10",
+        "vue-loader": "^15.7.1",
+        "vue-router": "^3.1.3",
+        "vue-server-renderer": "^2.6.10",
+        "vue-template-compiler": "^2.6.10",
+        "vuepress-html-webpack-plugin": "^3.2.0",
+        "vuepress-plugin-container": "^2.0.2",
+        "webpack": "^4.8.1",
+        "webpack-chain": "^6.0.0",
+        "webpack-dev-server": "^3.5.1",
+        "webpack-merge": "^4.1.2",
+        "webpackbar": "3.2.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cross-spawn/download/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lru-cache/download/lru-cache-5.1.1.tgz",
+          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yallist/download/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+          "dev": true
+        }
+      }
+    },
+    "@vuepress/markdown": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/markdown/download/@vuepress/markdown-1.5.4.tgz",
+      "integrity": "sha1-2XNttDADS3tgWGlsTaHMIRAyu+o=",
+      "dev": true,
+      "requires": {
+        "@vuepress/shared-utils": "1.5.4",
+        "markdown-it": "^8.4.1",
+        "markdown-it-anchor": "^5.0.2",
+        "markdown-it-chain": "^1.3.0",
+        "markdown-it-emoji": "^1.4.0",
+        "markdown-it-table-of-contents": "^0.4.0",
+        "prismjs": "^1.13.0"
+      }
+    },
+    "@vuepress/markdown-loader": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/markdown-loader/download/@vuepress/markdown-loader-1.5.4.tgz",
+      "integrity": "sha1-m6SbvpyU7XknFFia72ogx+0KyCI=",
+      "dev": true,
+      "requires": {
+        "@vuepress/markdown": "1.5.4",
+        "loader-utils": "^1.1.0",
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lru-cache/download/lru-cache-5.1.1.tgz",
+          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yallist/download/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+          "dev": true
+        }
+      }
+    },
+    "@vuepress/plugin-active-header-links": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/plugin-active-header-links/download/@vuepress/plugin-active-header-links-1.5.4.tgz",
+      "integrity": "sha1-/7+84NWTIJEEO3ZnV2g8o7VCCu8=",
+      "dev": true,
+      "requires": {
+        "lodash.debounce": "^4.0.8"
+      }
+    },
+    "@vuepress/plugin-last-updated": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/plugin-last-updated/download/@vuepress/plugin-last-updated-1.5.4.tgz",
+      "integrity": "sha1-bz+f5yDOf4g8N93HGsAv6PNrv+Q=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cross-spawn/download/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
+    "@vuepress/plugin-nprogress": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/plugin-nprogress/download/@vuepress/plugin-nprogress-1.5.4.tgz",
+      "integrity": "sha1-uBjrysWt22SIv1DrIVhUUPUq5Aw=",
+      "dev": true,
+      "requires": {
+        "nprogress": "^0.2.0"
+      }
+    },
+    "@vuepress/plugin-register-components": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/plugin-register-components/download/@vuepress/plugin-register-components-1.5.4.tgz",
+      "integrity": "sha1-L2LQeQRx71OTX/LICNgEXARzBn8=",
+      "dev": true,
+      "requires": {
+        "@vuepress/shared-utils": "1.5.4"
+      }
+    },
+    "@vuepress/plugin-search": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/plugin-search/download/@vuepress/plugin-search-1.5.4.tgz",
+      "integrity": "sha1-M2BEXp7Pi9y1SXqxwPRtiuzJq2w=",
+      "dev": true
+    },
+    "@vuepress/shared-utils": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/shared-utils/download/@vuepress/shared-utils-1.5.4.tgz",
+      "integrity": "sha1-0shpO4zTVNOhOnb49CWTNeVUAJk=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.2",
+        "escape-html": "^1.0.3",
+        "fs-extra": "^7.0.1",
+        "globby": "^9.2.0",
+        "gray-matter": "^4.0.1",
+        "hash-sum": "^1.0.2",
+        "semver": "^6.0.0",
+        "toml": "^3.0.0",
+        "upath": "^1.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@vuepress/theme-default": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@vuepress/theme-default/download/@vuepress/theme-default-1.5.4.tgz",
+      "integrity": "sha1-d9sn/nw87RWpcGRN8CArDv++hl8=",
+      "dev": true,
+      "requires": {
+        "@vuepress/plugin-active-header-links": "1.5.4",
+        "@vuepress/plugin-nprogress": "1.5.4",
+        "@vuepress/plugin-search": "1.5.4",
+        "docsearch.js": "^2.5.2",
+        "lodash": "^4.17.15",
+        "stylus": "^0.54.5",
+        "stylus-loader": "^3.0.2",
+        "vuepress-plugin-container": "^2.0.2",
+        "vuepress-plugin-smooth-scroll": "^0.0.3"
+      }
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/ast/download/@webassemblyjs/ast-1.9.0.tgz",
+      "integrity": "sha1-vYUGBLQEJFmlpBzX0zjL7Wle2WQ=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/floating-point-hex-parser/download/@webassemblyjs/floating-point-hex-parser-1.9.0.tgz",
+      "integrity": "sha1-PD07Jxvd/ITesA9xNEQ4MR1S/7Q=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/helper-api-error/download/@webassemblyjs/helper-api-error-1.9.0.tgz",
+      "integrity": "sha1-ID9nbjM7lsnaLuqzzO8zxFkotqI=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/helper-buffer/download/@webassemblyjs/helper-buffer-1.9.0.tgz",
+      "integrity": "sha1-oUQtJpxf6yP8vJ73WdrDVH8p3gA=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-code-frame": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/helper-code-frame/download/@webassemblyjs/helper-code-frame-1.9.0.tgz",
+      "integrity": "sha1-ZH+Iks0gQ6gqwMjF51w28dkVnyc=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "@webassemblyjs/helper-fsm": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/helper-fsm/download/@webassemblyjs/helper-fsm-1.9.0.tgz",
+      "integrity": "sha1-wFJWtxJEIUZx9LCOwQitY7cO3bg=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-module-context": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/helper-module-context/download/@webassemblyjs/helper-module-context-1.9.0.tgz",
+      "integrity": "sha1-JdiIS3aDmHGgimxvgGw5ee9xLwc=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/helper-wasm-bytecode/download/@webassemblyjs/helper-wasm-bytecode-1.9.0.tgz",
+      "integrity": "sha1-T+2L6sm4wU+MWLcNEk1UndH+V5A=",
+      "dev": true
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/helper-wasm-section/download/@webassemblyjs/helper-wasm-section-1.9.0.tgz",
+      "integrity": "sha1-WkE41aYpK6GLBMWuSXF+QWeWU0Y=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/ieee754/download/@webassemblyjs/ieee754-1.9.0.tgz",
+      "integrity": "sha1-Fceg+6roP7JhQ7us9tbfFwKtOeQ=",
+      "dev": true,
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/leb128/download/@webassemblyjs/leb128-1.9.0.tgz",
+      "integrity": "sha1-8Zygt2ptxVYjoJz/p2noOPoeHJU=",
+      "dev": true,
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/utf8/download/@webassemblyjs/utf8-1.9.0.tgz",
+      "integrity": "sha1-BNM7Y2945qaBMifoJAL3Y3tiKas=",
+      "dev": true
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/wasm-edit/download/@webassemblyjs/wasm-edit-1.9.0.tgz",
+      "integrity": "sha1-P+bXnT8PkiGDqoYALELdJWz+6c8=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/helper-wasm-section": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-opt": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "@webassemblyjs/wast-printer": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/wasm-gen/download/@webassemblyjs/wasm-gen-1.9.0.tgz",
+      "integrity": "sha1-ULxw7Gje2OJ2OwGhQYv0NJGnpJw=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/wasm-opt/download/@webassemblyjs/wasm-opt-1.9.0.tgz",
+      "integrity": "sha1-IhEYHlsxMmRDzIES658LkChyGmE=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-buffer": "1.9.0",
+        "@webassemblyjs/wasm-gen": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/wasm-parser/download/@webassemblyjs/wasm-parser-1.9.0.tgz",
+      "integrity": "sha1-nUjkSCbfSmWYKUqmyHRp1kL/9l4=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+        "@webassemblyjs/ieee754": "1.9.0",
+        "@webassemblyjs/leb128": "1.9.0",
+        "@webassemblyjs/utf8": "1.9.0"
+      }
+    },
+    "@webassemblyjs/wast-parser": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/wast-parser/download/@webassemblyjs/wast-parser-1.9.0.tgz",
+      "integrity": "sha1-MDERXXmsW9JhVWzsw/qQo+9FGRQ=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+        "@webassemblyjs/helper-api-error": "1.9.0",
+        "@webassemblyjs/helper-code-frame": "1.9.0",
+        "@webassemblyjs/helper-fsm": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@webassemblyjs/wast-printer/download/@webassemblyjs/wast-printer-1.9.0.tgz",
+      "integrity": "sha1-STXVTIX+9jewDOn1I3dFHQDUeJk=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/wast-parser": "1.9.0",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@xtuc/ieee754/download/@xtuc/ieee754-1.2.0.tgz",
+      "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+      "dev": true
+    },
+    "@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/@xtuc/long/download/@xtuc/long-4.2.2.tgz",
+      "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
+      "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/abbrev/download/abbrev-1.1.1.tgz",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "dev": true
+    },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/accepts/download/accepts-1.3.7.tgz",
+      "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
+    "acorn": {
+      "version": "6.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/acorn/download/acorn-6.4.1.tgz",
+      "integrity": "sha1-Ux5Yuj9RudrLmmZGyk3r9bFMpHQ=",
+      "dev": true
+    },
+    "agentkeepalive": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/agentkeepalive/download/agentkeepalive-2.2.0.tgz",
+      "integrity": "sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8=",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ajv/download/ajv-6.12.5.tgz",
+      "integrity": "sha1-GbDouuj0duW6ZmMAOHd1+xoApNo=",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-errors": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ajv-errors/download/ajv-errors-1.0.1.tgz",
+      "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
+      "dev": true
+    },
+    "ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ajv-keywords/download/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
+      "dev": true
+    },
+    "algoliasearch": {
+      "version": "4.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/algoliasearch/download/algoliasearch-4.5.1.tgz",
+      "integrity": "sha1-/SDNdva6P77N1OEb2u/vtEq8Czg=",
+      "requires": {
+        "@algolia/cache-browser-local-storage": "4.5.1",
+        "@algolia/cache-common": "4.5.1",
+        "@algolia/cache-in-memory": "4.5.1",
+        "@algolia/client-account": "4.5.1",
+        "@algolia/client-analytics": "4.5.1",
+        "@algolia/client-common": "4.5.1",
+        "@algolia/client-recommendation": "4.5.1",
+        "@algolia/client-search": "4.5.1",
+        "@algolia/logger-common": "4.5.1",
+        "@algolia/logger-console": "4.5.1",
+        "@algolia/requester-browser-xhr": "4.5.1",
+        "@algolia/requester-common": "4.5.1",
+        "@algolia/requester-node-http": "4.5.1",
+        "@algolia/transporter": "4.5.1"
+      }
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/alphanum-sort/download/alphanum-sort-1.0.2.tgz",
+      "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
+      "dev": true
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/amdefine/download/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
+    "ansi-align": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-align/download/ansi-align-3.0.0.tgz",
+      "integrity": "sha1-tTazcc9ofKrvI2wY0+If43l0Z8s=",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.0.0"
+      }
+    },
+    "ansi-colors": {
+      "version": "3.2.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-colors/download/ansi-colors-3.2.4.tgz",
+      "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
+      "dev": true
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-escapes/download/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      }
+    },
+    "ansi-html": {
+      "version": "0.0.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-html/download/ansi-html-0.0.7.tgz",
+      "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-4.1.0.tgz",
+      "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-styles/download/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/anymatch/download/anymatch-2.0.0.tgz",
+      "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/normalize-path/download/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        }
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/aproba/download/aproba-1.2.0.tgz",
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "dev": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/are-we-there-yet/download/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
+      "dev": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/argparse/download/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/arr-diff/download/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/arr-flatten/download/arr-flatten-1.1.0.tgz",
+      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/arr-union/download/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/array-find-index/download/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "2.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/array-flatten/download/array-flatten-2.1.2.tgz",
+      "integrity": "sha1-JO+AoowaiTYX4hSbDG0NeIKTsJk=",
+      "dev": true
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/array-union/download/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/array-uniq/download/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/array-unique/download/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+      "dev": true
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/asn1/download/asn1-0.2.4.tgz",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/asn1.js/download/asn1.js-5.4.1.tgz",
+      "integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "assert": {
+      "version": "1.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/assert/download/assert-1.5.0.tgz",
+      "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/inherits/download/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/util/download/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/assert-plus/download/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/assign-symbols/download/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/async/download/async-2.6.3.tgz",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "async-each": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/async-each/download/async-each-1.0.3.tgz",
+      "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
+      "dev": true
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/async-foreach/download/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "dev": true
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/async-limiter/download/async-limiter-1.0.1.tgz",
+      "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/asynckit/download/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/atob/download/atob-2.1.2.tgz",
+      "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+      "dev": true
+    },
+    "autocomplete.js": {
+      "version": "0.36.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/autocomplete.js/download/autocomplete.js-0.36.0.tgz",
+      "integrity": "sha1-lP53X+ZLbNQuYi0Hbcf9Jr7dg3s=",
+      "dev": true,
+      "requires": {
+        "immediate": "^3.2.3"
+      }
+    },
+    "autoprefixer": {
+      "version": "9.8.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/autoprefixer/download/autoprefixer-9.8.6.tgz",
+      "integrity": "sha1-O3NZTKG/kmYyDFrPFYjXTep0IQ8=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.12.0",
+        "caniuse-lite": "^1.0.30001109",
+        "colorette": "^1.2.1",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^7.0.32",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/aws-sign2/download/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.10.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/aws4/download/aws4-1.10.1.tgz",
+      "integrity": "sha1-4eguTz6Zniz9YbFhKA0WoRH4ZCg=",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/axios/download/axios-0.19.2.tgz",
+      "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
+    "babel-loader": {
+      "version": "8.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/babel-loader/download/babel-loader-8.1.0.tgz",
+      "integrity": "sha1-xhHVESvVIJq+i5+oTD5NolJ18cM=",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^2.1.0",
+        "loader-utils": "^1.4.0",
+        "mkdirp": "^0.5.3",
+        "pify": "^4.0.1",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/babel-plugin-dynamic-import-node/download/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha1-hP2hnJduxcbe/vV/lCez3vZuF6M=",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/balanced-match/download/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/base/download/base-0.11.2.tgz",
+      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/base64-js/download/base64-js-1.3.1.tgz",
+      "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
+      "dev": true
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/batch/download/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+      "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bcrypt-pbkdf/download/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "big.js": {
+      "version": "5.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/big.js/download/big.js-5.2.2.tgz",
+      "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "1.13.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/binary-extensions/download/binary-extensions-1.13.1.tgz",
+      "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+      "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bindings/download/bindings-1.5.0.tgz",
+      "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/block-stream/download/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bluebird/download/bluebird-3.7.2.tgz",
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "5.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-5.1.3.tgz",
+      "integrity": "sha1-vsoAVAj2Quvr6oCwQrTRjSrA7ms=",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/body-parser/download/body-parser-1.19.0.tgz",
+      "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bytes/download/bytes-3.1.0.tgz",
+          "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/qs/download/qs-6.7.0.tgz",
+          "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
+          "dev": true
+        }
+      }
+    },
+    "bonjour": {
+      "version": "3.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bonjour/download/bonjour-3.5.0.tgz",
+      "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+      "dev": true,
+      "requires": {
+        "array-flatten": "^2.1.0",
+        "deep-equal": "^1.0.1",
+        "dns-equal": "^1.0.0",
+        "dns-txt": "^2.0.2",
+        "multicast-dns": "^6.0.1",
+        "multicast-dns-service-types": "^1.1.0"
+      }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/boolbase/download/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
+    "boxen": {
+      "version": "4.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/boxen/download/boxen-4.2.0.tgz",
+      "integrity": "sha1-5BG2I1fW1tNlh8isPV2XTaoHDmQ=",
+      "dev": true,
+      "requires": {
+        "ansi-align": "^3.0.0",
+        "camelcase": "^5.3.1",
+        "chalk": "^3.0.0",
+        "cli-boxes": "^2.2.0",
+        "string-width": "^4.1.0",
+        "term-size": "^2.1.0",
+        "type-fest": "^0.8.1",
+        "widest-line": "^3.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-styles/download/ansi-styles-4.2.1.tgz",
+          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color-convert/download/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color-name/download/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/emoji-regex/download/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-flag/download/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string-width/download/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/type-fest/download/type-fest-0.8.1.tgz",
+          "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+          "dev": true
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/brace-expansion/download/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/braces/download/braces-2.3.2.tgz",
+      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/brorand/download/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/browserify-aes/download/browserify-aes-1.2.0.tgz",
+      "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "^1.0.3",
+        "cipher-base": "^1.0.0",
+        "create-hash": "^1.1.0",
+        "evp_bytestokey": "^1.0.3",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/browserify-cipher/download/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "^1.0.4",
+        "browserify-des": "^1.0.0",
+        "evp_bytestokey": "^1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/browserify-des/download/browserify-des-1.0.2.tgz",
+      "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "des.js": "^1.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/browserify-rsa/download/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "browserify-sign": {
+      "version": "4.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/browserify-sign/download/browserify-sign-4.2.1.tgz",
+      "integrity": "sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^5.1.1",
+        "browserify-rsa": "^4.0.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.5.3",
+        "inherits": "^2.0.4",
+        "parse-asn1": "^5.1.5",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/readable-stream/download/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/safe-buffer/download/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/browserify-zlib/download/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+      "dev": true,
+      "requires": {
+        "pako": "~1.0.5"
+      }
+    },
+    "browserslist": {
+      "version": "4.14.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/browserslist/download/browserslist-4.14.4.tgz",
+      "integrity": "sha1-ZqGBMUOfnhbD2n81JRjfoS9gsOM=",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001135",
+        "electron-to-chromium": "^1.3.570",
+        "escalade": "^3.1.0",
+        "node-releases": "^1.1.61"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/buffer/download/buffer-4.9.2.tgz",
+      "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/buffer-from/download/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "buffer-indexof": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/buffer-indexof/download/buffer-indexof-1.1.1.tgz",
+      "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
+      "dev": true
+    },
+    "buffer-json": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/buffer-json/download/buffer-json-2.0.0.tgz",
+      "integrity": "sha1-9z4TseQvGW/i/WfQAcfXEH7dfCM=",
+      "dev": true
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/buffer-xor/download/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/builtin-status-codes/download/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bytes/download/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "cac": {
+      "version": "6.6.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cac/download/cac-6.6.1.tgz",
+      "integrity": "sha1-Pd4/aUP0XUKlZynqNXPAiz57am0=",
+      "dev": true
+    },
+    "cacache": {
+      "version": "12.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cacache/download/cacache-12.0.4.tgz",
+      "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
+        "mkdirp": "^0.5.1",
+        "move-concurrently": "^1.0.1",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
+        "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lru-cache/download/lru-cache-5.1.1.tgz",
+          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yallist/download/yallist-3.1.1.tgz",
+          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+          "dev": true
+        }
+      }
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cache-base/download/cache-base-1.0.1.tgz",
+      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
+    "cache-loader": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cache-loader/download/cache-loader-3.0.1.tgz",
+      "integrity": "sha1-zubPSzzcfGEJBbJrrWwvxDnIIa8=",
+      "dev": true,
+      "requires": {
+        "buffer-json": "^2.0.0",
+        "find-cache-dir": "^2.1.0",
+        "loader-utils": "^1.2.3",
+        "mkdirp": "^0.5.1",
+        "neo-async": "^2.6.1",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "cacheable-request": {
+      "version": "6.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cacheable-request/download/cacheable-request-6.1.0.tgz",
+      "integrity": "sha1-IP+4vRYrpL4R6VZ9gj22UQUsqRI=",
+      "dev": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^3.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
+        "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/get-stream/download/get-stream-5.2.0.tgz",
+          "integrity": "sha1-SWaheV7lrOZecGxLe+txJX1uItM=",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lowercase-keys/download/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha1-JgPni3tLAAbLyi+8yKMgJVislHk=",
+          "dev": true
+        },
+        "normalize-url": {
+          "version": "4.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/normalize-url/download/normalize-url-4.5.0.tgz",
+          "integrity": "sha1-RTNUCH5sqWlXvY9br3U/WYIUISk=",
+          "dev": true
+        }
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/call-me-maybe/download/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/caller-callsite/download/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/caller-path/download/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
+    "callsites": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/callsites/download/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/camel-case/download/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/camelcase/download/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/camelcase-keys/download/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/camelcase/download/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true
+        }
+      }
+    },
+    "caniuse-api": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/caniuse-api/download/caniuse-api-3.0.0.tgz",
+      "integrity": "sha1-Xk2Q4idJYdRikZl99Znj7QCO5MA=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001135",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/caniuse-lite/download/caniuse-lite-1.0.30001135.tgz",
+      "integrity": "sha1-mVseuUQEo8mg12AMETybsn8s2Ko=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/caseless/download/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-styles/download/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "chokidar": {
+      "version": "2.1.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chokidar/download/chokidar-2.1.8.tgz",
+      "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+      "dev": true,
+      "requires": {
+        "anymatch": "^2.0.0",
+        "async-each": "^1.0.1",
+        "braces": "^2.3.2",
+        "fsevents": "^1.2.7",
+        "glob-parent": "^3.1.0",
+        "inherits": "^2.0.3",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.2.1",
+        "upath": "^1.1.1"
+      }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chownr/download/chownr-1.1.4.tgz",
+      "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
+      "dev": true
+    },
+    "chrome-trace-event": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chrome-trace-event/download/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "ci-info": {
+      "version": "1.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ci-info/download/ci-info-1.6.0.tgz",
+      "integrity": "sha1-LKINu5zrMtRSSmgzAzE/AwSx5Jc=",
+      "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cipher-base/download/cipher-base-1.0.4.tgz",
+      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/class-utils/download/class-utils-0.3.6.tgz",
+      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/clean-css/download/clean-css-4.2.3.tgz",
+      "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "cli-boxes": {
+      "version": "2.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cli-boxes/download/cli-boxes-2.2.1.tgz",
+      "integrity": "sha1-3dUDXSUJT84iDpyrQKRYQKRAMY8=",
+      "dev": true
+    },
+    "clipboard": {
+      "version": "2.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/clipboard/download/clipboard-2.0.6.tgz",
+      "integrity": "sha1-UpISlu7A/fd+rRdJQhshyWhkc3Y=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cliui/download/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/clone-deep/download/clone-deep-4.0.1.tgz",
+      "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/clone-response/download/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "coa": {
+      "version": "2.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/coa/download/coa-2.0.2.tgz",
+      "integrity": "sha1-Q/bCEVG07yv1cYfbDXPeIp4+fsM=",
+      "dev": true,
+      "requires": {
+        "@types/q": "^1.5.1",
+        "chalk": "^2.4.1",
+        "q": "^1.1.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/code-point-at/download/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/collection-visit/download/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
+    },
+    "color": {
+      "version": "3.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color/download/color-3.1.2.tgz",
+      "integrity": "sha1-aBSOf4XUGtdknF+oyBBvCY0inhA=",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color-convert/download/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color-name/download/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color-string/download/color-string-1.5.3.tgz",
+      "integrity": "sha1-ybvF8BtYtUkvPWhXRZy2WQziBMw=",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/colorette/download/colorette-1.2.1.tgz",
+      "integrity": "sha1-TQuSEyXBT6+SYzCGpTbbbolWSxs=",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/combined-stream/download/combined-stream-1.0.8.tgz",
+      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/commander/download/commander-2.17.1.tgz",
+      "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/commondir/download/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/component-emitter/download/component-emitter-1.3.0.tgz",
+      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
+      "dev": true
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/compressible/download/compressible-2.0.18.tgz",
+      "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/compression/download/compression-1.7.4.tgz",
+      "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/concat-map/download/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/concat-stream/download/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "configstore": {
+      "version": "5.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/configstore/download/configstore-5.0.1.tgz",
+      "integrity": "sha1-02UCG130uYzdGH1qOw4/anzF7ZY=",
+      "dev": true,
+      "requires": {
+        "dot-prop": "^5.2.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/make-dir/download/make-dir-3.1.0.tgz",
+          "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/connect-history-api-fallback/download/connect-history-api-fallback-1.6.0.tgz",
+      "integrity": "sha1-izIIk1kwjRERFdgcrT/Oq4iPl7w=",
+      "dev": true
+    },
+    "consola": {
+      "version": "2.15.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/consola/download/consola-2.15.0.tgz",
+      "integrity": "sha1-QPxO76TS+O8uKAYUfwVuogf8wOk=",
+      "dev": true
+    },
+    "console-browserify": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/console-browserify/download/console-browserify-1.2.0.tgz",
+      "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+      "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/console-control-strings/download/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
+    },
+    "consolidate": {
+      "version": "0.15.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/consolidate/download/consolidate-0.15.1.tgz",
+      "integrity": "sha1-IasEMjXHGgfUXZqtmFk7DbpWurc=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.1.1"
+      }
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/constants-browserify/download/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/content-disposition/download/content-disposition-0.5.3.tgz",
+      "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/content-type/download/content-type-1.0.4.tgz",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/convert-source-map/download/convert-source-map-1.7.0.tgz",
+      "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cookie/download/cookie-0.4.0.tgz",
+      "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cookie-signature/download/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/copy-concurrently/download/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "fs-write-stream-atomic": "^1.0.8",
+        "iferr": "^0.1.5",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.0"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/copy-descriptor/download/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
+    "copy-webpack-plugin": {
+      "version": "5.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/copy-webpack-plugin/download/copy-webpack-plugin-5.1.2.tgz",
+      "integrity": "sha1-ioieHcr6bJHGzUvhrRWPHTgjuuI=",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.3",
+        "find-cache-dir": "^2.1.0",
+        "glob-parent": "^3.1.0",
+        "globby": "^7.1.1",
+        "is-glob": "^4.0.1",
+        "loader-utils": "^1.2.3",
+        "minimatch": "^3.0.4",
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^4.0.0",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "7.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/globby/download/globby-7.1.1.tgz",
+          "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ignore/download/ignore-3.3.10.tgz",
+          "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "slash": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/slash/download/slash-1.0.0.tgz",
+          "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+          "dev": true
+        }
+      }
+    },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/core-js/download/core-js-3.6.5.tgz",
+      "integrity": "sha1-c5XcJzrzf7LlDpvT2f6EEoUjHRo=",
+      "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.6.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/core-js-compat/download/core-js-compat-3.6.5.tgz",
+      "integrity": "sha1-KlHZpOJd/W5pAlGqgfmePAVIHxw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.8.5",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-7.0.0.tgz",
+          "integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44=",
+          "dev": true
+        }
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/core-util-is/download/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cosmiconfig/download/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/parse-json/download/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        }
+      }
+    },
+    "create-ecdh": {
+      "version": "4.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/create-ecdh/download/create-ecdh-4.0.4.tgz",
+      "integrity": "sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "elliptic": "^6.5.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/create-hash/download/create-hash-1.2.0.tgz",
+      "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/create-hmac/download/create-hmac-1.1.7.tgz",
+      "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "cross-spawn": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cross-spawn/download/cross-spawn-3.0.1.tgz",
+      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.12.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/crypto-browserify/download/crypto-browserify-3.12.0.tgz",
+      "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "^1.0.0",
+        "browserify-sign": "^4.0.0",
+        "create-ecdh": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "create-hmac": "^1.1.0",
+        "diffie-hellman": "^5.0.0",
+        "inherits": "^2.0.1",
+        "pbkdf2": "^3.0.3",
+        "public-encrypt": "^4.0.0",
+        "randombytes": "^2.0.0",
+        "randomfill": "^1.0.3"
+      }
+    },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/crypto-random-string/download/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha1-7yp6lm7BEIM4g2m6oC6+rSKbMNU=",
+      "dev": true
+    },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css/download/css-2.2.4.tgz",
+      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-color-names/download/css-color-names-0.0.4.tgz",
+      "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
+      "dev": true
+    },
+    "css-declaration-sorter": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-declaration-sorter/download/css-declaration-sorter-4.0.1.tgz",
+      "integrity": "sha1-wZiUD2OnbX42wecQGLABchBUyyI=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.1",
+        "timsort": "^0.3.0"
+      }
+    },
+    "css-loader": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-loader/download/css-loader-2.1.1.tgz",
+      "integrity": "sha1-2CVPcuQSuyI4u0TdZ0/770lzM+o=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.2.0",
+        "icss-utils": "^4.1.0",
+        "loader-utils": "^1.2.3",
+        "normalize-path": "^3.0.0",
+        "postcss": "^7.0.14",
+        "postcss-modules-extract-imports": "^2.0.0",
+        "postcss-modules-local-by-default": "^2.0.6",
+        "postcss-modules-scope": "^2.1.0",
+        "postcss-modules-values": "^2.0.0",
+        "postcss-value-parser": "^3.3.0",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "css-parse": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-parse/download/css-parse-2.0.0.tgz",
+      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
+      "dev": true,
+      "requires": {
+        "css": "^2.0.0"
+      }
+    },
+    "css-select": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-select/download/css-select-2.1.0.tgz",
+      "integrity": "sha1-ajRlM1ZjWTSoG6ymjQJVQyEF2+8=",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0",
+        "css-what": "^3.2.1",
+        "domutils": "^1.7.0",
+        "nth-check": "^1.0.2"
+      }
+    },
+    "css-select-base-adapter": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-select-base-adapter/download/css-select-base-adapter-0.1.1.tgz",
+      "integrity": "sha1-Oy/0lyzDYquIVhUHqVQIoUMhNdc=",
+      "dev": true
+    },
+    "css-tree": {
+      "version": "1.0.0-alpha.37",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-tree/download/css-tree-1.0.0-alpha.37.tgz",
+      "integrity": "sha1-mL69YsTB2flg7DQM+fdSLjBwmiI=",
+      "dev": true,
+      "requires": {
+        "mdn-data": "2.0.4",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "css-what": {
+      "version": "3.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-what/download/css-what-3.3.0.tgz",
+      "integrity": "sha1-EP7Glqns4uWRrHctdZqsq6w4zTk=",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cssesc/download/cssesc-3.0.0.tgz",
+      "integrity": "sha1-N3QZGZA7hoVl4cCep0dEXNGJg+4=",
+      "dev": true
+    },
+    "cssnano": {
+      "version": "4.1.10",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cssnano/download/cssnano-4.1.10.tgz",
+      "integrity": "sha1-CsQfCxPRPUZUh+ERt3jULaYxuLI=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.0.0",
+        "cssnano-preset-default": "^4.0.7",
+        "is-resolvable": "^1.0.0",
+        "postcss": "^7.0.0"
+      }
+    },
+    "cssnano-preset-default": {
+      "version": "4.0.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cssnano-preset-default/download/cssnano-preset-default-4.0.7.tgz",
+      "integrity": "sha1-UexmLM/KD4izltzZZ5zbkxvhf3Y=",
+      "dev": true,
+      "requires": {
+        "css-declaration-sorter": "^4.0.1",
+        "cssnano-util-raw-cache": "^4.0.1",
+        "postcss": "^7.0.0",
+        "postcss-calc": "^7.0.1",
+        "postcss-colormin": "^4.0.3",
+        "postcss-convert-values": "^4.0.1",
+        "postcss-discard-comments": "^4.0.2",
+        "postcss-discard-duplicates": "^4.0.2",
+        "postcss-discard-empty": "^4.0.1",
+        "postcss-discard-overridden": "^4.0.1",
+        "postcss-merge-longhand": "^4.0.11",
+        "postcss-merge-rules": "^4.0.3",
+        "postcss-minify-font-values": "^4.0.2",
+        "postcss-minify-gradients": "^4.0.2",
+        "postcss-minify-params": "^4.0.2",
+        "postcss-minify-selectors": "^4.0.2",
+        "postcss-normalize-charset": "^4.0.1",
+        "postcss-normalize-display-values": "^4.0.2",
+        "postcss-normalize-positions": "^4.0.2",
+        "postcss-normalize-repeat-style": "^4.0.2",
+        "postcss-normalize-string": "^4.0.2",
+        "postcss-normalize-timing-functions": "^4.0.2",
+        "postcss-normalize-unicode": "^4.0.1",
+        "postcss-normalize-url": "^4.0.1",
+        "postcss-normalize-whitespace": "^4.0.2",
+        "postcss-ordered-values": "^4.1.2",
+        "postcss-reduce-initial": "^4.0.3",
+        "postcss-reduce-transforms": "^4.0.2",
+        "postcss-svgo": "^4.0.2",
+        "postcss-unique-selectors": "^4.0.1"
+      }
+    },
+    "cssnano-util-get-arguments": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cssnano-util-get-arguments/download/cssnano-util-get-arguments-4.0.0.tgz",
+      "integrity": "sha1-7ToIKZ8h11dBsg87gfGU7UnMFQ8=",
+      "dev": true
+    },
+    "cssnano-util-get-match": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cssnano-util-get-match/download/cssnano-util-get-match-4.0.0.tgz",
+      "integrity": "sha1-wOTKB/U4a7F+xeUiULT1lhNlFW0=",
+      "dev": true
+    },
+    "cssnano-util-raw-cache": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cssnano-util-raw-cache/download/cssnano-util-raw-cache-4.0.1.tgz",
+      "integrity": "sha1-sm1f1fcqEd/np4RvtMZyYPlr8oI=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "cssnano-util-same-parent": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cssnano-util-same-parent/download/cssnano-util-same-parent-4.0.1.tgz",
+      "integrity": "sha1-V0CC+yhZ0ttDOFWDXZqEVuoYu/M=",
+      "dev": true
+    },
+    "csso": {
+      "version": "4.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/csso/download/csso-4.0.3.tgz",
+      "integrity": "sha1-DZmF3IUsfMKyys+74QeQFNGo6QM=",
+      "dev": true,
+      "requires": {
+        "css-tree": "1.0.0-alpha.39"
+      },
+      "dependencies": {
+        "css-tree": {
+          "version": "1.0.0-alpha.39",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-tree/download/css-tree-1.0.0-alpha.39.tgz",
+          "integrity": "sha1-K/8//huz93bPfu/ZHuXLp3oUnus=",
+          "dev": true,
+          "requires": {
+            "mdn-data": "2.0.6",
+            "source-map": "^0.6.1"
+          }
+        },
+        "mdn-data": {
+          "version": "2.0.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mdn-data/download/mdn-data-2.0.6.tgz",
+          "integrity": "sha1-hS3GD8ql2qLoz2yRicRA7T4EKXg=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/currently-unhandled/download/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "cyclist": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cyclist/download/cyclist-1.0.1.tgz",
+      "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dashdash/download/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "de-indent": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/de-indent/download/de-indent-1.0.2.tgz",
+      "integrity": "sha1-sgOOhG3DO6pXlhKNCAS0VbjB4h0=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-3.1.0.tgz",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/decamelize/download/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/decode-uri-component/download/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/decompress-response/download/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/deep-equal/download/deep-equal-1.1.1.tgz",
+      "integrity": "sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=",
+      "dev": true,
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/deep-extend/download/deep-extend-0.6.0.tgz",
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "1.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/deepmerge/download/deepmerge-1.5.2.tgz",
+      "integrity": "sha1-EEmdhohEza1P7ghC34x/bwyVp1M=",
+      "dev": true
+    },
+    "default-gateway": {
+      "version": "4.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/default-gateway/download/default-gateway-4.2.0.tgz",
+      "integrity": "sha1-FnEEx1AMIRX23WmwpTa7jtcgVSs=",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "ip-regex": "^2.1.0"
+      }
+    },
+    "defer-to-connect": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/defer-to-connect/download/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha1-MxrgUMCNz3ifjIOnuB8O2U9KxZE=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-properties/download/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-2.0.2.tgz",
+      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "del": {
+      "version": "4.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/del/download/del-4.1.1.tgz",
+      "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "globby": "^6.1.0",
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/globby/download/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+          "dev": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/delayed-stream/download/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/delegate/download/delegate-3.2.0.tgz",
+      "integrity": "sha1-tmtxwxWFIuirV0T3INjKDCr1kWY=",
+      "dev": true,
+      "optional": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/delegates/download/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/depd/download/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "des.js": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/des.js/download/des.js-1.0.1.tgz",
+      "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/destroy/download/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/detect-node/download/detect-node-2.0.4.tgz",
+      "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
+      "dev": true
+    },
+    "diffie-hellman": {
+      "version": "5.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/diffie-hellman/download/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "miller-rabin": "^4.0.0",
+        "randombytes": "^2.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "2.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dir-glob/download/dir-glob-2.2.2.tgz",
+      "integrity": "sha1-+gnwaUFTyJGLGLoN6vrpR2n8UMQ=",
+      "dev": true,
+      "requires": {
+        "path-type": "^3.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-type/download/path-type-3.0.0.tgz",
+          "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dns-equal/download/dns-equal-1.0.0.tgz",
+      "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+      "dev": true
+    },
+    "dns-packet": {
+      "version": "1.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dns-packet/download/dns-packet-1.3.1.tgz",
+      "integrity": "sha1-EqpCaYEHW+UAuRDu3NC0fdfe2lo=",
+      "dev": true,
+      "requires": {
+        "ip": "^1.1.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "dns-txt": {
+      "version": "2.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dns-txt/download/dns-txt-2.0.2.tgz",
+      "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+      "dev": true,
+      "requires": {
+        "buffer-indexof": "^1.0.0"
+      }
+    },
+    "docsearch.js": {
+      "version": "2.6.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/docsearch.js/download/docsearch.js-2.6.3.tgz",
+      "integrity": "sha1-V8tGANO2VTxnfny75qc0WT44Yl0=",
+      "dev": true,
+      "requires": {
+        "algoliasearch": "^3.24.5",
+        "autocomplete.js": "0.36.0",
+        "hogan.js": "^3.0.2",
+        "request": "^2.87.0",
+        "stack-utils": "^1.0.1",
+        "to-factory": "^1.0.0",
+        "zepto": "^1.2.0"
+      },
+      "dependencies": {
+        "algoliasearch": {
+          "version": "3.35.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/algoliasearch/download/algoliasearch-3.35.1.tgz",
+          "integrity": "sha1-KX0V9TSjUHyrL137mWAZysdWjww=",
+          "dev": true,
+          "requires": {
+            "agentkeepalive": "^2.2.0",
+            "debug": "^2.6.9",
+            "envify": "^4.0.0",
+            "es6-promise": "^4.1.0",
+            "events": "^1.1.0",
+            "foreach": "^2.0.5",
+            "global": "^4.3.2",
+            "inherits": "^2.0.1",
+            "isarray": "^2.0.1",
+            "load-script": "^1.0.0",
+            "object-keys": "^1.0.11",
+            "querystring-es3": "^0.2.1",
+            "reduce": "^1.0.1",
+            "semver": "^5.1.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/events/download/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/isarray/download/isarray-2.0.5.tgz",
+          "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+          "dev": true
+        }
+      }
+    },
+    "dom-converter": {
+      "version": "0.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dom-converter/download/dom-converter-0.2.0.tgz",
+      "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
+      "dev": true,
+      "requires": {
+        "utila": "~0.4"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dom-serializer/download/dom-serializer-0.2.2.tgz",
+      "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/domelementtype/download/domelementtype-2.0.2.tgz",
+          "integrity": "sha1-87blSSAeRvWItZRj3XcYcTH+aXE=",
+          "dev": true
+        },
+        "entities": {
+          "version": "2.0.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/entities/download/entities-2.0.3.tgz",
+          "integrity": "sha1-XEh+V0Krk8Fau12iJ1m4WQ7AO38=",
+          "dev": true
+        }
+      }
+    },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dom-walk/download/dom-walk-0.1.2.tgz",
+      "integrity": "sha1-DFSL7wSPTR8qlySQAiNgYNqj/YQ=",
+      "dev": true
+    },
+    "domain-browser": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/domain-browser/download/domain-browser-1.2.0.tgz",
+      "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+      "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/domelementtype/download/domelementtype-1.3.1.tgz",
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/domhandler/download/domhandler-2.4.2.tgz",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/domutils/download/domutils-1.7.0.tgz",
+      "integrity": "sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "dot-prop": {
+      "version": "5.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/dot-prop/download/dot-prop-5.3.0.tgz",
+      "integrity": "sha1-kMzOcIzZzYLMTcjD3dmr3VWyDog=",
+      "dev": true,
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/duplexer3/download/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/duplexify/download/duplexify-3.7.1.tgz",
+      "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ecc-jsbn/download/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ee-first/download/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.571",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/electron-to-chromium/download/electron-to-chromium-1.3.571.tgz",
+      "integrity": "sha1-5Xl38VafgyauKnkF4m85Q1Nroo8=",
+      "dev": true
+    },
+    "elliptic": {
+      "version": "6.5.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/elliptic/download/elliptic-6.5.3.tgz",
+      "integrity": "sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/emoji-regex/download/emoji-regex-7.0.3.tgz",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY="
+    },
+    "emojis-list": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/emojis-list/download/emojis-list-3.0.0.tgz",
+      "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/encodeurl/download/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/end-of-stream/download/end-of-stream-1.4.4.tgz",
+      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "enhanced-resolve": {
+      "version": "4.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/enhanced-resolve/download/enhanced-resolve-4.3.0.tgz",
+      "integrity": "sha1-O4BvO/r8HsfeaVUe+TzKRsFwQSY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.5.0",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/memory-fs/download/memory-fs-0.5.0.tgz",
+          "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
+          "dev": true,
+          "requires": {
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
+          }
+        }
+      }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/entities/download/entities-1.1.2.tgz",
+      "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
+      "dev": true
+    },
+    "envify": {
+      "version": "4.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/envify/download/envify-4.1.0.tgz",
+      "integrity": "sha1-85rT251oAbTmtHi2ECjT8LaBn34=",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.0",
+        "through": "~2.3.4"
+      }
+    },
+    "envinfo": {
+      "version": "7.7.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/envinfo/download/envinfo-7.7.3.tgz",
+      "integrity": "sha1-Sy2GIuPnNmr7gJGyPtlVaeoCCMw=",
+      "dev": true
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/errno/download/errno-0.1.7.tgz",
+      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
+      "dev": true,
+      "requires": {
+        "prr": "~1.0.1"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/error-ex/download/error-ex-1.3.2.tgz",
+      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.18.0-next.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.18.0-next.0.tgz",
+      "integrity": "sha1-swKDSSfmJNjlg37UgiQpHyxm5vw=",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-to-primitive/download/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es6-promise/download/es6-promise-4.2.8.tgz",
+      "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
+      "dev": true
+    },
+    "escalade": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/escalade/download/escalade-3.1.0.tgz",
+      "integrity": "sha1-6OLXx6i3b27mTCGB1rgVFEFgLU4=",
+      "dev": true
+    },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/escape-goat/download/escape-goat-2.1.1.tgz",
+      "integrity": "sha1-Gy3HcANnbEV+x2Cy3GjttkgYhnU=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/escape-html/download/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/eslint-scope/download/eslint-scope-4.0.3.tgz",
+      "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/esprima/download/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/esrecurse/download/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/estraverse/download/estraverse-5.2.0.tgz",
+          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/estraverse/download/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/esutils/download/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/etag/download/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/eventemitter3/download/eventemitter3-4.0.7.tgz",
+      "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8=",
+      "dev": true
+    },
+    "events": {
+      "version": "3.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/events/download/events-3.2.0.tgz",
+      "integrity": "sha1-k7h8GPjvzUICpGGuxN/AVWtjk3k=",
+      "dev": true
+    },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/eventsource/download/eventsource-1.0.7.tgz",
+      "integrity": "sha1-j7xyyT/NNAiAkLwKTmT0tc7m2NA=",
+      "dev": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
+    "evp_bytestokey": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/evp_bytestokey/download/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+      "dev": true,
+      "requires": {
+        "md5.js": "^1.3.4",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/execa/download/execa-1.0.0.tgz",
+      "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/cross-spawn/download/cross-spawn-6.0.5.tgz",
+          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/expand-brackets/download/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/express/download/express-4.17.1.tgz",
+      "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "1.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/array-flatten/download/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/qs/download/qs-6.7.0.tgz",
+          "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
+          "dev": true
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend/download/extend-3.0.2.tgz",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+      "dev": true
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extglob/download/extglob-2.0.4.tgz",
+      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extsprintf/download/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fast-deep-equal/download/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "2.2.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fast-glob/download/fast-glob-2.2.7.tgz",
+      "integrity": "sha1-aVOFfDr6R1//ku5gFdUtpwpM050=",
+      "dev": true,
+      "requires": {
+        "@mrmlnc/readdir-enhanced": "^2.2.1",
+        "@nodelib/fs.stat": "^1.1.2",
+        "glob-parent": "^3.1.0",
+        "is-glob": "^4.0.0",
+        "merge2": "^1.2.3",
+        "micromatch": "^3.1.10"
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fast-json-stable-stringify/download/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/faye-websocket/download/faye-websocket-0.10.0.tgz",
+      "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "figgy-pudding": {
+      "version": "3.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/figgy-pudding/download/figgy-pudding-3.5.2.tgz",
+      "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/figures/download/figures-3.2.0.tgz",
+      "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-loader": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/file-loader/download/file-loader-3.0.1.tgz",
+      "integrity": "sha1-+OC6C1mZGLUa3+RdZtHnca1WD6o=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/file-uri-to-path/download/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+      "dev": true,
+      "optional": true
+    },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fill-range/download/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/finalhandler/download/finalhandler-1.1.2.tgz",
+      "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/find-cache-dir/download/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/find-up/download/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flush-write-stream": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/flush-write-stream/download/flush-write-stream-1.1.1.tgz",
+      "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.3.6"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/follow-redirects/download/follow-redirects-1.5.10.tgz",
+      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
+      "requires": {
+        "debug": "=3.1.0"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/for-in/download/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/foreach/download/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/forever-agent/download/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/form-data/download/form-data-2.3.3.tgz",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/forwarded/download/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fragment-cache/download/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fresh/download/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/from2/download/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "7.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fs-extra/download/fs-extra-7.0.1.tgz",
+      "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fs-write-stream-atomic/download/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "iferr": "^0.1.5",
+        "imurmurhash": "^0.1.4",
+        "readable-stream": "1 || 2"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fs.realpath/download/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fsevents/download/fsevents-1.2.13.tgz",
+      "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
+    },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fstream/download/fstream-1.0.12.tgz",
+      "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/function-bind/download/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/gauge/download/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-fullwidth-code-point/download/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string-width/download/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "gaze": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/gaze/download/gaze-1.1.3.tgz",
+      "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
+      "dev": true,
+      "requires": {
+        "globule": "^1.0.0"
+      }
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/gensync/download/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha1-WPQ2H/mH5f9uHnohCCeqNx6qwmk=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/get-caller-file/download/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34="
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/get-stdin/download/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/get-stream/download/get-stream-4.1.0.tgz",
+      "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/get-value/download/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/getpass/download/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/glob/download/glob-7.1.6.tgz",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/glob-parent/download/glob-parent-3.1.0.tgz",
+      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^3.1.0",
+        "path-dirname": "^1.0.0"
+      },
+      "dependencies": {
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-glob/download/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.0"
+          }
+        }
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/glob-to-regexp/download/glob-to-regexp-0.3.0.tgz",
+      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+      "dev": true
+    },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/global/download/global-4.4.0.tgz",
+      "integrity": "sha1-PnsQUXkAajI+1xqvyj6cV6XMZAY=",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
+    "global-dirs": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/global-dirs/download/global-dirs-2.0.1.tgz",
+      "integrity": "sha1-rN87tmhbzVXLNeigUiZlaelGkgE=",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5"
+      }
+    },
+    "globals": {
+      "version": "11.12.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/globals/download/globals-11.12.0.tgz",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+      "dev": true
+    },
+    "globby": {
+      "version": "9.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/globby/download/globby-9.2.0.tgz",
+      "integrity": "sha1-/QKacGxwPSm90XD0tts6P3p8tj0=",
+      "dev": true,
+      "requires": {
+        "@types/glob": "^7.1.1",
+        "array-union": "^1.0.2",
+        "dir-glob": "^2.2.2",
+        "fast-glob": "^2.2.6",
+        "glob": "^7.1.3",
+        "ignore": "^4.0.3",
+        "pify": "^4.0.1",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        }
+      }
+    },
+    "globule": {
+      "version": "1.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/globule/download/globule-1.3.2.tgz",
+      "integrity": "sha1-2L3Z6eTu+PluJFmZpd7n612FKcQ=",
+      "dev": true,
+      "requires": {
+        "glob": "~7.1.1",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/good-listener/download/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
+    "got": {
+      "version": "9.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/got/download/got-9.6.0.tgz",
+      "integrity": "sha1-7fRefWf5lUVwXeH3u+7rEhdl7YU=",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.14.0",
+        "@szmarczak/http-timer": "^1.1.2",
+        "cacheable-request": "^6.0.0",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^4.1.0",
+        "lowercase-keys": "^1.0.1",
+        "mimic-response": "^1.0.1",
+        "p-cancelable": "^1.0.0",
+        "to-readable-stream": "^1.0.0",
+        "url-parse-lax": "^3.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/graceful-fs/download/graceful-fs-4.2.4.tgz",
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
+      "dev": true
+    },
+    "gray-matter": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/gray-matter/download/gray-matter-4.0.2.tgz",
+      "integrity": "sha1-mqN546yvQhGT/OfSoozr1FGKxFQ=",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.11.0",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      }
+    },
+    "handle-thing": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/handle-thing/download/handle-thing-2.0.1.tgz",
+      "integrity": "sha1-hX95zjWVgMNA1DCBzGSJcNC7I04=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/har-schema/download/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/har-validator/download/har-validator-5.1.5.tgz",
+      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has/download/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-ansi/download/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-flag/download/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-symbols/download/has-symbols-1.0.1.tgz",
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-unicode/download/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-value/download/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-values/download/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "has-yarn": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-yarn/download/has-yarn-2.1.0.tgz",
+      "integrity": "sha1-E34RNUp7W/EapctknPDG8/8rLnc=",
+      "dev": true
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hash-base/download/hash-base-3.1.0.tgz",
+      "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/readable-stream/download/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/safe-buffer/download/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
+        }
+      }
+    },
+    "hash-sum": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hash-sum/download/hash-sum-1.0.2.tgz",
+      "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
+      "dev": true
+    },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hash.js/download/hash.js-1.1.7.tgz",
+      "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/he/download/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
+      "dev": true
+    },
+    "hex-color-regex": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hex-color-regex/download/hex-color-regex-1.1.0.tgz",
+      "integrity": "sha1-TAb8y0YC/iYCs8k9+C1+fb8aio4=",
+      "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hmac-drbg/download/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "hogan.js": {
+      "version": "3.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hogan.js/download/hogan.js-3.0.2.tgz",
+      "integrity": "sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.3.0",
+        "nopt": "1.0.10"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mkdirp/download/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/nopt/download/nopt-1.0.10.tgz",
+          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        }
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hosted-git-info/download/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
+      "dev": true
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hpack.js/download/hpack.js-2.1.6.tgz",
+      "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
+    "hsl-regex": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hsl-regex/download/hsl-regex-1.0.0.tgz",
+      "integrity": "sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=",
+      "dev": true
+    },
+    "hsla-regex": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/hsla-regex/download/hsla-regex-1.0.0.tgz",
+      "integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
+      "dev": true
+    },
+    "html-comment-regex": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/html-comment-regex/download/html-comment-regex-1.1.2.tgz",
+      "integrity": "sha1-l9RoiutcgYhqNk+qDK0d2hTUM6c=",
+      "dev": true
+    },
+    "html-entities": {
+      "version": "1.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/html-entities/download/html-entities-1.3.1.tgz",
+      "integrity": "sha1-+5oaS1sUxdq6gtPjTGrk/nAaDkQ=",
+      "dev": true
+    },
+    "html-minifier": {
+      "version": "3.5.21",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/html-minifier/download/html-minifier-3.5.21.tgz",
+      "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
+      }
+    },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/html-tags/download/html-tags-3.1.0.tgz",
+      "integrity": "sha1-e15vfmZen7QfMAB+2eDUHpf7IUA=",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/htmlparser2/download/htmlparser2-3.10.1.tgz",
+      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/readable-stream/download/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/http-cache-semantics/download/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha1-SekcXL82yblLz81xwj1SSex045A=",
+      "dev": true
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/http-deceiver/download/http-deceiver-1.2.7.tgz",
+      "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/http-errors/download/http-errors-1.7.2.tgz",
+      "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/inherits/download/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/http-proxy/download/http-proxy-1.18.1.tgz",
+      "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "0.19.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/http-proxy-middleware/download/http-proxy-middleware-0.19.1.tgz",
+      "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
+      "dev": true,
+      "requires": {
+        "http-proxy": "^1.17.0",
+        "is-glob": "^4.0.0",
+        "lodash": "^4.17.11",
+        "micromatch": "^3.1.10"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/http-signature/download/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-browserify": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/https-browserify/download/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/iconv-lite/download/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/icss-replace-symbols/download/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha1-Bupvg2ead0njhs/h/oEq5dsiPe0=",
+      "dev": true
+    },
+    "icss-utils": {
+      "version": "4.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/icss-utils/download/icss-utils-4.1.1.tgz",
+      "integrity": "sha1-IRcLU3ie4nRHwvR91oMIFAP5pGc=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
+      }
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ieee754/download/ieee754-1.1.13.tgz",
+      "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
+      "dev": true
+    },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/iferr/download/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ignore/download/ignore-4.0.6.tgz",
+      "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+      "dev": true
+    },
+    "immediate": {
+      "version": "3.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/immediate/download/immediate-3.3.0.tgz",
+      "integrity": "sha1-Gu8iVReDa8338qLeJgDHn/AmkmY=",
+      "dev": true
+    },
+    "import-cwd": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/import-cwd/download/import-cwd-2.1.0.tgz",
+      "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+      "dev": true,
+      "requires": {
+        "import-from": "^2.1.0"
+      }
+    },
+    "import-fresh": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/import-fresh/download/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      }
+    },
+    "import-from": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/import-from/download/import-from-2.1.0.tgz",
+      "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      }
+    },
+    "import-lazy": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/import-lazy/download/import-lazy-2.1.0.tgz",
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
+    },
+    "import-local": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/import-local/download/import-local-2.0.0.tgz",
+      "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/imurmurhash/download/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "in-publish": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/in-publish/download/in-publish-2.0.1.tgz",
+      "integrity": "sha1-lIsaU1yAMFYc6lIvc/ePS+NX4Aw=",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/indent-string/download/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/indexes-of/download/indexes-of-1.0.1.tgz",
+      "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
+      "dev": true
+    },
+    "infer-owner": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/infer-owner/download/infer-owner-1.0.4.tgz",
+      "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/inflight/download/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/inherits/download/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ini/download/ini-1.3.5.tgz",
+      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "dev": true
+    },
+    "internal-ip": {
+      "version": "4.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/internal-ip/download/internal-ip-4.3.0.tgz",
+      "integrity": "sha1-hFRSuq2dLKO2nGNaE3rLmg2tCQc=",
+      "dev": true,
+      "requires": {
+        "default-gateway": "^4.2.0",
+        "ipaddr.js": "^1.9.0"
+      }
+    },
+    "intersection-observer": {
+      "version": "0.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/intersection-observer/download/intersection-observer-0.11.0.tgz",
+      "integrity": "sha1-9OoGcHAyb2g5PuFhzAospMAEDG8="
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/invariant/download/invariant-2.2.4.tgz",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ip/download/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+      "dev": true
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ip-regex/download/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ipaddr.js/download/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
+      "dev": true
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-absolute-url/download/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+      "dev": true
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-accessor-descriptor/download/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-arguments/download/is-arguments-1.0.4.tgz",
+      "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-arrayish/download/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-binary-path/download/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^1.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-buffer/download/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-callable/download/is-callable-1.2.2.tgz",
+      "integrity": "sha1-x8ZxXNItTdtI0+GZcCI6zquwgNk=",
+      "dev": true
+    },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-ci/download/is-ci-2.0.0.tgz",
+      "integrity": "sha1-a8YzQYGBDgS1wis9WJ/cpVAmQEw=",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0"
+      },
+      "dependencies": {
+        "ci-info": {
+          "version": "2.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ci-info/download/ci-info-2.0.0.tgz",
+          "integrity": "sha1-Z6npZL4xpR4V5QENWObxKDQAL0Y=",
+          "dev": true
+        }
+      }
+    },
+    "is-color-stop": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-color-stop/download/is-color-stop-1.1.0.tgz",
+      "integrity": "sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=",
+      "dev": true,
+      "requires": {
+        "css-color-names": "^0.0.4",
+        "hex-color-regex": "^1.1.0",
+        "hsl-regex": "^1.0.0",
+        "hsla-regex": "^1.0.0",
+        "rgb-regex": "^1.0.1",
+        "rgba-regex": "^1.0.0"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-data-descriptor/download/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-date-object/download/is-date-object-1.0.2.tgz",
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-descriptor/download/is-descriptor-0.1.6.tgz",
+      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-5.1.0.tgz",
+          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+          "dev": true
+        }
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-directory/download/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-extendable/download/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-extglob/download/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-finite/download/is-finite-1.1.0.tgz",
+      "integrity": "sha1-kEE1x3+0LAZB1qobzbxNqo2ggvM=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-fullwidth-code-point/download/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-glob/download/is-glob-4.0.1.tgz",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-installed-globally": {
+      "version": "0.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-installed-globally/download/is-installed-globally-0.3.2.tgz",
+      "integrity": "sha1-/T76ee5nDRGHIzGC1bCh3QAxMUE=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "^2.0.1",
+        "is-path-inside": "^3.0.1"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "3.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-path-inside/download/is-path-inside-3.0.2.tgz",
+          "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc=",
+          "dev": true
+        }
+      }
+    },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-negative-zero/download/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
+    },
+    "is-npm": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-npm/download/is-npm-4.0.0.tgz",
+      "integrity": "sha1-yQ3YOAaW34enptgjwg0LErvjyE0=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-number/download/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-obj/download/is-obj-2.0.0.tgz",
+      "integrity": "sha1-Rz+wXZc3BeP9liBUUBjKjiLvSYI=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-path-cwd/download/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-path-in-cwd/download/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "^2.1.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-path-inside/download/is-path-inside-2.1.0.tgz",
+      "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "^1.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-plain-obj/download/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-plain-object/download/is-plain-object-2.0.4.tgz",
+      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-regex": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-regex/download/is-regex-1.1.1.tgz",
+      "integrity": "sha1-xvmKrMVG9s7FRooHt7FTq1ZKV7k=",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-resolvable/download/is-resolvable-1.1.0.tgz",
+      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-stream/download/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-svg": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-svg/download/is-svg-3.0.0.tgz",
+      "integrity": "sha1-kyHb0pwhLlypnE+peUxxS8r6L3U=",
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "^1.1.0"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-symbol/download/is-symbol-1.0.3.tgz",
+      "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-typedarray/download/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-utf8/download/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-windows/download/is-windows-1.0.2.tgz",
+      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-wsl/download/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true
+    },
+    "is-yarn-global": {
+      "version": "0.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-yarn-global/download/is-yarn-global-0.3.0.tgz",
+      "integrity": "sha1-1QLTOCWQ6jAEiTdGdUyJE5lz4jI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/isarray/download/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/isexe/download/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/isobject/download/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/isstream/download/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "javascript-stringify": {
+      "version": "1.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/javascript-stringify/download/javascript-stringify-1.6.0.tgz",
+      "integrity": "sha1-FC0RHzpuPa6PSpr9d9RYVbWpzOM=",
+      "dev": true
+    },
+    "js-base64": {
+      "version": "2.6.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/js-base64/download/js-base64-2.6.4.tgz",
+      "integrity": "sha1-9OaGxd4eofhn28rT1G2WlCjfmMQ=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/js-tokens/download/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/js-yaml/download/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/jsbn/download/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/jsesc/download/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "dev": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json-buffer/download/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json-parse-better-errors/download/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json-schema/download/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json-schema-traverse/download/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json-stringify-safe/download/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json3/download/json3-3.3.3.tgz",
+      "integrity": "sha1-f8EON1/FrkLEcFpcwKpvYr4wW4E=",
+      "dev": true
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json5/download/json5-1.0.1.tgz",
+      "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/jsonfile/download/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/jsprim/download/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "keyv": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/keyv/download/keyv-3.1.0.tgz",
+      "integrity": "sha1-7MIoSG9pmR5J6UdkhaW+Ho/FxNk=",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "killable": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/killable/download/killable-1.0.1.tgz",
+      "integrity": "sha1-TIzkQRh6Bhx0dPuHygjipjgZSJI=",
+      "dev": true
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-6.0.3.tgz",
+      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+      "dev": true
+    },
+    "last-call-webpack-plugin": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/last-call-webpack-plugin/download/last-call-webpack-plugin-3.0.0.tgz",
+      "integrity": "sha1-l0LfDhDjz0blwDgcLekNOnotdVU=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5",
+        "webpack-sources": "^1.1.0"
+      }
+    },
+    "latest-version": {
+      "version": "5.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/latest-version/download/latest-version-5.1.0.tgz",
+      "integrity": "sha1-EZ3+kI/jjRXfpD7NE/oS7Igy+s4=",
+      "dev": true,
+      "requires": {
+        "package-json": "^6.3.0"
+      }
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/leven/download/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
+      "dev": true
+    },
+    "levenary": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/levenary/download/levenary-1.1.1.tgz",
+      "integrity": "sha1-hCqe6Y0gdap/ru2+MmeekgX0b3c=",
+      "dev": true,
+      "requires": {
+        "leven": "^3.1.0"
+      }
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/linkify-it/download/linkify-it-2.2.0.tgz",
+      "integrity": "sha1-47VGl+eL+RXHCjis14/QngBYsc8=",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/load-json-file/download/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      }
+    },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/load-script/download/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=",
+      "dev": true
+    },
+    "loader-runner": {
+      "version": "2.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/loader-runner/download/loader-runner-2.4.0.tgz",
+      "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
+      "dev": true
+    },
+    "loader-utils": {
+      "version": "1.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/loader-utils/download/loader-utils-1.4.0.tgz",
+      "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+      "dev": true,
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/locate-path/download/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash/download/lodash-4.17.20.tgz",
+      "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=",
+      "dev": true
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash._reinterpolate/download/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash.clonedeep/download/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash.debounce/download/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash.kebabcase/download/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha1-hImxyw0p/4gZXM7KRI/21swpXDY=",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash.memoize/download/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash.template/download/lodash.template-4.5.0.tgz",
+      "integrity": "sha1-+XYZXPPzR9DV9SSDVp/oAxzM6Ks=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash.templatesettings/download/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha1-5IExDwSdPPbUfpEq0JMTsVTw+zM=",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lodash.uniq/download/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
+    "loglevel": {
+      "version": "1.7.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/loglevel/download/loglevel-1.7.0.tgz",
+      "integrity": "sha1-coFmhVp0DVnTjbAc9G8ELKoEG7A=",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/loose-envify/download/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/loud-rejection/download/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lower-case/download/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lowercase-keys/download/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/lru-cache/download/lru-cache-4.1.5.tgz",
+      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/make-dir/download/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-4.0.1.tgz",
+          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+          "dev": true
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/map-cache/download/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/map-obj/download/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/map-visit/download/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
+    },
+    "markdown-it": {
+      "version": "8.4.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/markdown-it/download/markdown-it-8.4.2.tgz",
+      "integrity": "sha1-OG+YmY3BWjdyKqdyIIT0Agvdm1Q=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "5.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/markdown-it-anchor/download/markdown-it-anchor-5.3.0.tgz",
+      "integrity": "sha1-1Ums1khWqOzRvqWDZe84Xv+6x0Q=",
+      "dev": true
+    },
+    "markdown-it-chain": {
+      "version": "1.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/markdown-it-chain/download/markdown-it-chain-1.3.0.tgz",
+      "integrity": "sha1-zPb+hsECZrr7TlRzgN/X8nfMF7w=",
+      "dev": true,
+      "requires": {
+        "webpack-chain": "^4.9.0"
+      },
+      "dependencies": {
+        "webpack-chain": {
+          "version": "4.12.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack-chain/download/webpack-chain-4.12.1.tgz",
+          "integrity": "sha1-bIQ5u7KrVQlS1g4eqTGRQZBsAqY=",
+          "dev": true,
+          "requires": {
+            "deepmerge": "^1.5.2",
+            "javascript-stringify": "^1.6.0"
+          }
+        }
+      }
+    },
+    "markdown-it-container": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/markdown-it-container/download/markdown-it-container-2.0.0.tgz",
+      "integrity": "sha1-ABm0P9Au7+zi8ZYKKJX7qBpARpU=",
+      "dev": true
+    },
+    "markdown-it-emoji": {
+      "version": "1.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/markdown-it-emoji/download/markdown-it-emoji-1.4.0.tgz",
+      "integrity": "sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=",
+      "dev": true
+    },
+    "markdown-it-table-of-contents": {
+      "version": "0.4.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/markdown-it-table-of-contents/download/markdown-it-table-of-contents-0.4.4.tgz",
+      "integrity": "sha1-PcfOi4/BflmBx3zDmNF4Ixnzf7w=",
+      "dev": true
+    },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/md5.js/download/md5.js-1.3.5.tgz",
+      "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdn-data": {
+      "version": "2.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mdn-data/download/mdn-data-2.0.4.tgz",
+      "integrity": "sha1-aZs8OKxvHXKAkaZGULZdOIUC/Vs=",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mdurl/download/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/media-typer/download/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/memory-fs/download/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "dev": true,
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/meow/download/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/merge-descriptors/download/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/merge-source-map/download/merge-source-map-1.1.0.tgz",
+      "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/merge2/download/merge2-1.4.1.tgz",
+      "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/methods/download/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/micromatch/download/micromatch-3.1.10.tgz",
+      "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
+    "miller-rabin": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/miller-rabin/download/miller-rabin-4.0.1.tgz",
+      "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.0.0",
+        "brorand": "^1.0.1"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mime/download/mime-2.4.6.tgz",
+      "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mime-db/download/mime-db-1.44.0.tgz",
+      "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mime-types/download/mime-types-2.1.27.tgz",
+      "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.44.0"
+      }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mimic-response/download/mimic-response-1.0.1.tgz",
+      "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs=",
+      "dev": true
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/min-document/download/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
+    },
+    "mini-css-extract-plugin": {
+      "version": "0.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mini-css-extract-plugin/download/mini-css-extract-plugin-0.6.0.tgz",
+      "integrity": "sha1-o/Ezctb83pEvPuTNA5ZlcEgB47k=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "normalize-url": "^2.0.1",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/minimalistic-assert/download/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/minimalistic-crypto-utils/download/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/minimatch/download/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/minimist/download/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
+    },
+    "mississippi": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mississippi/download/mississippi-3.0.0.tgz",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.0",
+        "duplexify": "^3.4.2",
+        "end-of-stream": "^1.1.0",
+        "flush-write-stream": "^1.0.0",
+        "from2": "^2.1.0",
+        "parallel-transform": "^1.1.0",
+        "pump": "^3.0.0",
+        "pumpify": "^1.3.3",
+        "stream-each": "^1.1.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mixin-deep/download/mixin-deep-1.3.2.tgz",
+      "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-extendable/download/is-extendable-1.0.1.tgz",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mkdirp/download/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/move-concurrently/download/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1",
+        "copy-concurrently": "^1.0.0",
+        "fs-write-stream-atomic": "^1.0.8",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.4",
+        "run-queue": "^1.0.3"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multicast-dns": {
+      "version": "6.2.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/multicast-dns/download/multicast-dns-6.2.3.tgz",
+      "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
+      "dev": true,
+      "requires": {
+        "dns-packet": "^1.3.1",
+        "thunky": "^1.0.2"
+      }
+    },
+    "multicast-dns-service-types": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/multicast-dns-service-types/download/multicast-dns-service-types-1.1.0.tgz",
+      "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/nan/download/nan-2.14.1.tgz",
+      "integrity": "sha1-174036MQW5FJTDFHCJMV7/iHSwE=",
+      "dev": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/nanomatch/download/nanomatch-1.2.13.tgz",
+      "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/negotiator/download/negotiator-0.6.2.tgz",
+      "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/neo-async/download/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/nice-try/download/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+      "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/no-case/download/no-case-2.3.2.tgz",
+      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
+    "node-forge": {
+      "version": "0.10.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/node-forge/download/node-forge-0.10.0.tgz",
+      "integrity": "sha1-Mt6ir7Ppkm8C7lzoeUkCaRpna/M=",
+      "dev": true
+    },
+    "node-gyp": {
+      "version": "3.8.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/node-gyp/download/node-gyp-3.8.0.tgz",
+      "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
+      "dev": true,
+      "requires": {
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "^2.87.0",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "dev": true
+        }
+      }
+    },
+    "node-libs-browser": {
+      "version": "2.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/node-libs-browser/download/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
+      "dev": true,
+      "requires": {
+        "assert": "^1.1.1",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^4.3.0",
+        "console-browserify": "^1.1.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.11.0",
+        "domain-browser": "^1.1.1",
+        "events": "^3.0.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "0.0.1",
+        "process": "^0.11.10",
+        "punycode": "^1.2.4",
+        "querystring-es3": "^0.2.0",
+        "readable-stream": "^2.3.3",
+        "stream-browserify": "^2.0.1",
+        "stream-http": "^2.7.2",
+        "string_decoder": "^1.0.0",
+        "timers-browserify": "^2.0.4",
+        "tty-browserify": "0.0.0",
+        "url": "^0.11.0",
+        "util": "^0.11.0",
+        "vm-browserify": "^1.0.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/punycode/download/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "node-releases": {
+      "version": "1.1.61",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/node-releases/download/node-releases-1.1.61.tgz",
+      "integrity": "sha1-cHsPypzk4ReDYSukovy6CQR68W4=",
+      "dev": true
+    },
+    "node-sass": {
+      "version": "4.14.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/node-sass/download/node-sass-4.14.1.tgz",
+      "integrity": "sha1-mch+wu+3BH7WOPtMnbfzpC4iF7U=",
+      "dev": true,
+      "requires": {
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash": "^4.17.15",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.13.2",
+        "node-gyp": "^3.8.0",
+        "npmlog": "^4.0.0",
+        "request": "^2.88.0",
+        "sass-graph": "2.2.5",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/nopt/download/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/normalize-package-data/download/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/normalize-path/download/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "dev": true
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/normalize-range/download/normalize-range-0.1.2.tgz",
+      "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+      "dev": true
+    },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/normalize-url/download/normalize-url-2.0.1.tgz",
+      "integrity": "sha1-g1qdoVUfom9w6SMpBpojqmV01+Y=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/npm-run-path/download/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/npmlog/download/npmlog-4.1.2.tgz",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "dev": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "nprogress": {
+      "version": "0.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/nprogress/download/nprogress-0.2.0.tgz",
+      "integrity": "sha1-y480xTIT2JVyP8urkH6UIq28r7E=",
+      "dev": true
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/nth-check/download/nth-check-1.0.2.tgz",
+      "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
+      "dev": true,
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/num2fraction/download/num2fraction-1.2.2.tgz",
+      "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+      "dev": true
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/number-is-nan/download/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/oauth-sign/download/oauth-sign-0.9.0.tgz",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object-assign/download/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object-copy/download/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object-inspect/download/object-inspect-1.8.0.tgz",
+      "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
+      "dev": true
+    },
+    "object-is": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object-is/download/object-is-1.1.2.tgz",
+      "integrity": "sha1-xdLof/nhGfeLegiEQVGeLuwVc7Y=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.17.6.tgz",
+          "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object-keys/download/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object-visit/download/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object.assign/download/object.assign-4.1.1.tgz",
+      "integrity": "sha1-MDhnpmbN1Bk27N7fsfjz4ypHjN0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object.getownpropertydescriptors/download/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.17.6.tgz",
+          "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object.pick/download/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "object.values": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/object.values/download/object.values-1.1.1.tgz",
+      "integrity": "sha1-aKmezeNWt+kpWjxeDOMdyMlT3l4=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.17.6.tgz",
+          "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/obuf/download/obuf-1.1.2.tgz",
+      "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/on-finished/download/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/on-headers/download/on-headers-1.0.2.tgz",
+      "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/once/download/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/opencollective-postinstall/download/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha1-eg//l49tv6TQBiOPusmO1BmMMlk=",
+      "dev": true
+    },
+    "opn": {
+      "version": "5.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/opn/download/opn-5.5.0.tgz",
+      "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
+    "optimize-css-assets-webpack-plugin": {
+      "version": "5.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/optimize-css-assets-webpack-plugin/download/optimize-css-assets-webpack-plugin-5.0.4.tgz",
+      "integrity": "sha1-hYg8ZSiqoC4wu62ZCMkpJrtS3JA=",
+      "dev": true,
+      "requires": {
+        "cssnano": "^4.1.10",
+        "last-call-webpack-plugin": "^3.0.0"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/original/download/original-1.0.2.tgz",
+      "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
+    "os-browserify": {
+      "version": "0.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/os-browserify/download/os-browserify-0.3.0.tgz",
+      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+      "dev": true
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/os-homedir/download/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/os-tmpdir/download/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/osenv/download/osenv-0.1.5.tgz",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
+    },
+    "p-cancelable": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/p-cancelable/download/p-cancelable-1.1.0.tgz",
+      "integrity": "sha1-0HjRWjr0CSIMiG8dmgyi5EGrJsw=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/p-finally/download/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/p-limit/download/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/p-locate/download/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/p-map/download/p-map-2.1.0.tgz",
+      "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
+      "dev": true
+    },
+    "p-retry": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/p-retry/download/p-retry-3.0.1.tgz",
+      "integrity": "sha1-MWtMiJPiyNwc+okfQGxLQivr8yg=",
+      "dev": true,
+      "requires": {
+        "retry": "^0.12.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/p-try/download/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY="
+    },
+    "package-json": {
+      "version": "6.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/package-json/download/package-json-6.5.0.tgz",
+      "integrity": "sha1-b+7ayjXnVyWHbQsOZJdGl/7RRbA=",
+      "dev": true,
+      "requires": {
+        "got": "^9.6.0",
+        "registry-auth-token": "^4.0.0",
+        "registry-url": "^5.0.0",
+        "semver": "^6.2.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pako/download/pako-1.0.11.tgz",
+      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+      "dev": true
+    },
+    "parallel-transform": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/parallel-transform/download/parallel-transform-1.2.0.tgz",
+      "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
+      "dev": true,
+      "requires": {
+        "cyclist": "^1.0.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.1.5"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/param-case/download/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
+    "parse-asn1": {
+      "version": "5.1.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/parse-asn1/download/parse-asn1-5.1.6.tgz",
+      "integrity": "sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=",
+      "dev": true,
+      "requires": {
+        "asn1.js": "^5.2.0",
+        "browserify-aes": "^1.0.0",
+        "evp_bytestokey": "^1.0.0",
+        "pbkdf2": "^3.0.3",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/parse-json/download/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/parseurl/download/parseurl-1.3.3.tgz",
+      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pascalcase/download/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-browserify/download/path-browserify-0.0.1.tgz",
+      "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
+      "dev": true
+    },
+    "path-dirname": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-dirname/download/path-dirname-1.0.2.tgz",
+      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-exists/download/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-is-inside/download/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-key/download/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-parse/download/path-parse-1.0.6.tgz",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-to-regexp/download/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-type/download/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pbkdf2": {
+      "version": "3.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pbkdf2/download/pbkdf2-3.1.1.tgz",
+      "integrity": "sha1-y4cksPramEWWhW0abrr9NYRlS5Q=",
+      "dev": true,
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/performance-now/download/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/picomatch/download/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
+      "dev": true,
+      "optional": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pify/download/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pinkie/download/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pinkie-promise/download/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pkg-dir/download/pkg-dir-3.0.0.tgz",
+      "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.28",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/portfinder/download/portfinder-1.0.28.tgz",
+      "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
+    },
+    "postcss": {
+      "version": "7.0.34",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss/download/postcss-7.0.34.tgz",
+      "integrity": "sha1-8rr1fDYBDffeQAmUDyFTLBbWXCA=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-5.5.0.tgz",
+              "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postcss-calc": {
+      "version": "7.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-calc/download/postcss-calc-7.0.4.tgz",
+      "integrity": "sha1-Xhd920FzQebUoZPF2f2K2nkJT4s=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.27",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.0.2"
+      }
+    },
+    "postcss-colormin": {
+      "version": "4.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-colormin/download/postcss-colormin-4.0.3.tgz",
+      "integrity": "sha1-rgYLzpPteUrHEmTwgTLVUJVr04E=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "color": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-convert-values": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-convert-values/download/postcss-convert-values-4.0.1.tgz",
+      "integrity": "sha1-yjgT7U2g+BL51DcDWE5Enr4Ymn8=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-discard-comments": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-discard-comments/download/postcss-discard-comments-4.0.2.tgz",
+      "integrity": "sha1-H7q9LCRr/2qq15l7KwkY9NevQDM=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-duplicates": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-discard-duplicates/download/postcss-discard-duplicates-4.0.2.tgz",
+      "integrity": "sha1-P+EzzTyCKC5VD8myORdqkge3hOs=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-empty": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-discard-empty/download/postcss-discard-empty-4.0.1.tgz",
+      "integrity": "sha1-yMlR6fc+2UKAGUWERKAq2Qu592U=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-discard-overridden": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-discard-overridden/download/postcss-discard-overridden-4.0.1.tgz",
+      "integrity": "sha1-ZSrvipZybwKfXj4AFG7npOdV/1c=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-load-config": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-load-config/download/postcss-load-config-2.1.1.tgz",
+      "integrity": "sha1-CmhLuL6wXlW6+SL3q0TD7bF8944=",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^5.0.0",
+        "import-cwd": "^2.0.0"
+      }
+    },
+    "postcss-loader": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-loader/download/postcss-loader-3.0.0.tgz",
+      "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "postcss": "^7.0.0",
+        "postcss-load-config": "^2.0.0",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "postcss-merge-longhand": {
+      "version": "4.0.11",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-merge-longhand/download/postcss-merge-longhand-4.0.11.tgz",
+      "integrity": "sha1-YvSaE+Sg7gTnuY9CuxYGLKJUniQ=",
+      "dev": true,
+      "requires": {
+        "css-color-names": "0.0.4",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "stylehacks": "^4.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-merge-rules": {
+      "version": "4.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-merge-rules/download/postcss-merge-rules-4.0.3.tgz",
+      "integrity": "sha1-NivqT/Wh+Y5AdacTxsslrv75plA=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-util-same-parent": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0",
+        "vendors": "^1.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-minify-font-values": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-minify-font-values/download/postcss-minify-font-values-4.0.2.tgz",
+      "integrity": "sha1-zUw0TM5HQ0P6xdgiBqssvLiv1aY=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-minify-gradients": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-minify-gradients/download/postcss-minify-gradients-4.0.2.tgz",
+      "integrity": "sha1-k7KcL/UJnFNe7NpWxKpuZlpmNHE=",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "is-color-stop": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-minify-params": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-minify-params/download/postcss-minify-params-4.0.2.tgz",
+      "integrity": "sha1-a5zvAwwR41Jh+V9hjJADbWgNuHQ=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "browserslist": "^4.0.0",
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "uniqs": "^2.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-minify-selectors": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-minify-selectors/download/postcss-minify-selectors-4.0.2.tgz",
+      "integrity": "sha1-4uXrQL/uUA0M2SQ1APX46kJi+9g=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-modules-extract-imports/download/postcss-modules-extract-imports-2.0.0.tgz",
+      "integrity": "sha1-gYcZoa4doyX5gyRGsBE27rSTzX4=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.5"
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "2.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-modules-local-by-default/download/postcss-modules-local-by-default-2.0.6.tgz",
+      "integrity": "sha1-3ZlT9t1Ha1/R7y2IMMiSl2C1bmM=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0",
+        "postcss-value-parser": "^3.3.1"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-modules-scope/download/postcss-modules-scope-2.2.0.tgz",
+      "integrity": "sha1-OFyuATzHdD9afXYC0Qc6iequYu4=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-modules-values/download/postcss-modules-values-2.0.0.tgz",
+      "integrity": "sha1-R5tG3Axco9x/pScIUYNrnscVL2Q=",
+      "dev": true,
+      "requires": {
+        "icss-replace-symbols": "^1.1.0",
+        "postcss": "^7.0.6"
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-charset/download/postcss-normalize-charset-4.0.1.tgz",
+      "integrity": "sha1-izWt067oOhNrBHHg1ZvlilAoXdQ=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-normalize-display-values": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-display-values/download/postcss-normalize-display-values-4.0.2.tgz",
+      "integrity": "sha1-Db4EpM6QY9RmftK+R2u4MMglk1o=",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-positions": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-positions/download/postcss-normalize-positions-4.0.2.tgz",
+      "integrity": "sha1-BfdX+E8mBDc3g2ipH4ky1LECkX8=",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-repeat-style": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-repeat-style/download/postcss-normalize-repeat-style-4.0.2.tgz",
+      "integrity": "sha1-xOu8KJ85kaAo1EdRy90RkYsXkQw=",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-string": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-string/download/postcss-normalize-string-4.0.2.tgz",
+      "integrity": "sha1-zUTECrB6DHo23F6Zqs4eyk7CaQw=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-timing-functions": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-timing-functions/download/postcss-normalize-timing-functions-4.0.2.tgz",
+      "integrity": "sha1-jgCcoqOUnNr4rSPmtquZy159KNk=",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-unicode": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-unicode/download/postcss-normalize-unicode-4.0.1.tgz",
+      "integrity": "sha1-hBvUj9zzAZrUuqdJOj02O1KuHPs=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-url": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-url/download/postcss-normalize-url-4.0.1.tgz",
+      "integrity": "sha1-EOQ3+GvHx+WPe5ZS7YeNqqlfquE=",
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "^2.0.0",
+        "normalize-url": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "3.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/normalize-url/download/normalize-url-3.3.0.tgz",
+          "integrity": "sha1-suHE3E98bVd0PfczpPWXjRhlBVk=",
+          "dev": true
+        },
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-normalize-whitespace": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-normalize-whitespace/download/postcss-normalize-whitespace-4.0.2.tgz",
+      "integrity": "sha1-vx1AcP5Pzqh9E0joJdjMDF+qfYI=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-ordered-values": {
+      "version": "4.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-ordered-values/download/postcss-ordered-values-4.1.2.tgz",
+      "integrity": "sha1-DPdcgg7H1cTSgBiVWeC1ceusDu4=",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-arguments": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-reduce-initial": {
+      "version": "4.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-reduce-initial/download/postcss-reduce-initial-4.0.3.tgz",
+      "integrity": "sha1-f9QuvqXpyBRgljniwuhK4nC6SN8=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "caniuse-api": "^3.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0"
+      }
+    },
+    "postcss-reduce-transforms": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-reduce-transforms/download/postcss-reduce-transforms-4.0.2.tgz",
+      "integrity": "sha1-F++kBerMbge+NBSlyi0QdGgdTik=",
+      "dev": true,
+      "requires": {
+        "cssnano-util-get-match": "^4.0.0",
+        "has": "^1.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-safe-parser": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-safe-parser/download/postcss-safe-parser-4.0.2.tgz",
+      "integrity": "sha1-ptTkjw832ffBGypYG/APi6SHC5Y=",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.26"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-selector-parser/download/postcss-selector-parser-6.0.3.tgz",
+      "integrity": "sha1-dm13cocogXzBQPoaxtped/n62pg=",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "indexes-of": "^1.0.1",
+        "uniq": "^1.0.1",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-svgo": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-svgo/download/postcss-svgo-4.0.2.tgz",
+      "integrity": "sha1-F7mXvHEbMzurFDqu07jT1uPTglg=",
+      "dev": true,
+      "requires": {
+        "is-svg": "^3.0.0",
+        "postcss": "^7.0.0",
+        "postcss-value-parser": "^3.0.0",
+        "svgo": "^1.0.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
+      }
+    },
+    "postcss-unique-selectors": {
+      "version": "4.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-unique-selectors/download/postcss-unique-selectors-4.0.1.tgz",
+      "integrity": "sha1-lEaRHzKJv9ZMbWgPBzwDsfnuS6w=",
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "^1.0.0",
+        "postcss": "^7.0.0",
+        "uniqs": "^2.0.0"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-value-parser/download/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss=",
+      "dev": true
+    },
+    "preact": {
+      "version": "10.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/preact/download/preact-10.5.2.tgz",
+      "integrity": "sha1-TAfCf0I5ZmhA4NY37HwRDPyuGB0="
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/prepend-http/download/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/prettier/download/prettier-1.19.1.tgz",
+      "integrity": "sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=",
+      "dev": true,
+      "optional": true
+    },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pretty-error/download/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "dev": true,
+      "requires": {
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
+      }
+    },
+    "pretty-time": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pretty-time/download/pretty-time-1.1.0.tgz",
+      "integrity": "sha1-/7dCmvq7hTXDRqNOQYc63z103Q4=",
+      "dev": true
+    },
+    "prismjs": {
+      "version": "1.21.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/prismjs/download/prismjs-1.21.0.tgz",
+      "integrity": "sha1-NsCG7Da0UxnsQhjuFkwRD5/AFaM=",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/process/download/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/process-nextick-args/download/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+      "dev": true
+    },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/promise-inflight/download/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/proxy-addr/download/proxy-addr-2.0.6.tgz",
+      "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/prr/download/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pseudomap/download/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/psl/download/psl-1.8.0.tgz",
+      "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
+      "dev": true
+    },
+    "public-encrypt": {
+      "version": "4.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/public-encrypt/download/public-encrypt-4.0.3.tgz",
+      "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "^4.1.0",
+        "browserify-rsa": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "parse-asn1": "^5.0.0",
+        "randombytes": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bn.js/download/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+          "dev": true
+        }
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pump/download/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pumpify/download/pumpify-1.5.1.tgz",
+      "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+      "dev": true,
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pump/download/pump-2.0.1.tgz",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/punycode/download/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true
+    },
+    "pupa": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/pupa/download/pupa-2.0.1.tgz",
+      "integrity": "sha1-29yf9I/76komoGm2+fersFEAhyY=",
+      "dev": true,
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/q/download/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/qs/download/qs-6.5.2.tgz",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "dev": true
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/query-string/download/query-string-5.1.1.tgz",
+      "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
+      "dev": true,
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/querystring/download/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/querystring-es3/download/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/querystringify/download/querystringify-2.2.0.tgz",
+      "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y=",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/randombytes/download/randombytes-2.1.0.tgz",
+      "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "randomfill": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/randomfill/download/randomfill-1.0.4.tgz",
+      "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.0.5",
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/range-parser/download/range-parser-1.2.1.tgz",
+      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/raw-body/download/raw-body-2.4.0.tgz",
+      "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/bytes/download/bytes-3.1.0.tgz",
+          "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
+          "dev": true
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/rc/download/rc-1.2.8.tgz",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/read-pkg/download/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/read-pkg-up/download/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/find-up/download/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/path-exists/download/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/readable-stream/download/readable-stream-2.3.7.tgz",
+      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "2.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/readdirp/download/readdirp-2.2.1.tgz",
+      "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "micromatch": "^3.1.10",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/redent/download/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "reduce": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/reduce/download/reduce-1.0.2.tgz",
+      "integrity": "sha1-DNaArT/+CwYOV6XGi9/ONxaNNhs=",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.1.0"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regenerate/download/regenerate-1.4.1.tgz",
+      "integrity": "sha1-ytkq2Oa1kXc0hfvgWkhcr09Ffm8=",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regenerate-unicode-properties/download/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha1-5d5xEdZV57pgwFfb6f83yH5lzew=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regenerator-runtime/download/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regenerator-transform/download/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha1-yY2hVGg2ccnE3LFuznNlF+G3/rQ=",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regex-not/download/regex-not-1.0.2.tgz",
+      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regexp.prototype.flags/download/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha1-erqJs8E6ZFCdq888qNn7ub31y3U=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.17.6.tgz",
+          "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "regexpu-core": {
+      "version": "4.7.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regexpu-core/download/regexpu-core-4.7.1.tgz",
+      "integrity": "sha1-LepamgcjMpj78NuR+pq8TG4PitY=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "4.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/registry-auth-token/download/registry-auth-token-4.2.0.tgz",
+      "integrity": "sha1-HTff/acrvs0PWB5HFVQCE6Zet9o=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "registry-url": {
+      "version": "5.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/registry-url/download/registry-url-5.1.0.tgz",
+      "integrity": "sha1-6YM0tQ1UNLgRNrROxjjZwgCcUAk=",
+      "dev": true,
+      "requires": {
+        "rc": "^1.2.8"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regjsgen/download/regjsgen-0.5.2.tgz",
+      "integrity": "sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/regjsparser/download/regjsparser-0.6.4.tgz",
+      "integrity": "sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/jsesc/download/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/relateurl/download/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/remove-trailing-separator/download/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "renderkid": {
+      "version": "2.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/renderkid/download/renderkid-2.0.3.tgz",
+      "integrity": "sha1-OAF5wv9a4TZcUivy/Pz/AcW3QUk=",
+      "dev": true,
+      "requires": {
+        "css-select": "^1.1.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "^0.4.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "css-select": {
+          "version": "1.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-select/download/css-select-1.2.0.tgz",
+          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+          "dev": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "css-what": {
+          "version": "2.1.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/css-what/download/css-what-2.1.3.tgz",
+          "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI=",
+          "dev": true
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/domutils/download/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/repeat-element/download/repeat-element-1.1.3.tgz",
+      "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/repeat-string/download/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/repeating/download/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/request/download/request-2.88.2.tgz",
+      "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/require-directory/download/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/require-main-filename/download/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/requires-port/download/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.17.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/resolve/download/resolve-1.17.0.tgz",
+      "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/resolve-cwd/download/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/resolve-from/download/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/resolve-url/download/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/responselike/download/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ret/download/ret-0.1.15.tgz",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.12.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/retry/download/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "dev": true
+    },
+    "rgb-regex": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/rgb-regex/download/rgb-regex-1.0.1.tgz",
+      "integrity": "sha1-wODWiC3w4jviVKR16O3UGRX+rrE=",
+      "dev": true
+    },
+    "rgba-regex": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/rgba-regex/download/rgba-regex-1.0.0.tgz",
+      "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.7.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/rimraf/download/rimraf-2.7.1.tgz",
+      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ripemd160/download/ripemd160-2.0.2.tgz",
+      "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+      "dev": true,
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/run-queue/download/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "^1.1.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/safe-buffer/download/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/safe-regex/download/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/safer-buffer/download/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "sass-graph": {
+      "version": "2.2.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sass-graph/download/sass-graph-2.2.5.tgz",
+      "integrity": "sha1-qYHIdEa4MZ2W3OBnHkh4eb0kwug=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yargs/download/yargs-13.3.2.tgz",
+          "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yargs-parser/download/yargs-parser-13.1.2.tgz",
+          "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "sass-loader": {
+      "version": "8.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sass-loader/download/sass-loader-8.0.2.tgz",
+      "integrity": "sha1-3r7NjDziQ8dkVPLoKQSCFQOACQ0=",
+      "dev": true,
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "loader-utils": "^1.2.3",
+        "neo-async": "^2.6.1",
+        "schema-utils": "^2.6.1",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sax/download/sax-1.2.4.tgz",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "dev": true
+    },
+    "schema-utils": {
+      "version": "2.7.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-2.7.1.tgz",
+      "integrity": "sha1-HKTzLRskxZDCA7jnpQvw6kzTlNc=",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.5",
+        "ajv": "^6.12.4",
+        "ajv-keywords": "^3.5.2"
+      }
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/scss-tokenizer/download/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "dev": true,
+      "requires": {
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
+      }
+    },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/section-matter/download/section-matter-1.0.0.tgz",
+      "integrity": "sha1-6QQZU1BngOwB1Z8pKhnHuFC4QWc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/select/download/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/select-hose/download/select-hose-2.0.0.tgz",
+      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "dev": true
+    },
+    "selfsigned": {
+      "version": "1.10.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/selfsigned/download/selfsigned-1.10.8.tgz",
+      "integrity": "sha1-DRcgi30Swz+OrIXEGDXyf8PYGjA=",
+      "dev": true,
+      "requires": {
+        "node-forge": "^0.10.0"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-5.7.1.tgz",
+      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "3.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver-diff/download/semver-diff-3.1.1.tgz",
+      "integrity": "sha1-Bfd85Z8yXgDicGr9Z7tQbdscoys=",
+      "dev": true,
+      "requires": {
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
+      }
+    },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/send/download/send-0.17.1.tgz",
+      "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mime/download/mime-1.6.0.tgz",
+          "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+          "dev": true
+        }
+      }
+    },
+    "serialize-javascript": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/serialize-javascript/download/serialize-javascript-4.0.0.tgz",
+      "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/serve-index/download/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/http-errors/download/http-errors-1.6.3.tgz",
+          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/inherits/download/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/setprototypeof/download/setprototypeof-1.1.0.tgz",
+          "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/serve-static/download/serve-static-1.14.1.tgz",
+      "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      }
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/set-blocking/download/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-value": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/set-value/download/set-value-2.0.1.tgz",
+      "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/setimmediate/download/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/setprototypeof/download/setprototypeof-1.1.1.tgz",
+      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sha.js/download/sha.js-2.4.11.tgz",
+      "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/shallow-clone/download/shallow-clone-3.0.1.tgz",
+      "integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/shebang-command/download/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/shebang-regex/download/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "showdown": {
+      "version": "1.9.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/showdown/download/showdown-1.9.1.tgz",
+      "integrity": "sha1-E04UjnXNRiPgnCGwURl315ta0O8=",
+      "requires": {
+        "yargs": "^14.2"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/signal-exit/download/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+      "dev": true
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/simple-swizzle/download/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-arrayish/download/is-arrayish-0.3.2.tgz",
+          "integrity": "sha1-RXSirlb3qyBolvtDHq7tBm/fjwM=",
+          "dev": true
+        }
+      }
+    },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/slash/download/slash-2.0.0.tgz",
+      "integrity": "sha1-3lUoUaF1nfOo8gZTVEL17E3eq0Q=",
+      "dev": true
+    },
+    "smoothscroll-polyfill": {
+      "version": "0.4.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/smoothscroll-polyfill/download/smoothscroll-polyfill-0.4.4.tgz",
+      "integrity": "sha1-OiWRMdxpMObKgAA+HLA7YDtpq/g=",
+      "dev": true
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/snapdragon/download/snapdragon-0.8.2.tgz",
+      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/extend-shallow/download/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/snapdragon-node/download/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-accessor-descriptor/download/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-data-descriptor/download/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-descriptor/download/is-descriptor-1.0.2.tgz",
+          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/snapdragon-util/download/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "sockjs": {
+      "version": "0.3.20",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sockjs/download/sockjs-0.3.20.tgz",
+      "integrity": "sha1-smooPsVi74smh7RAM6Tuzqx12FU=",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "^0.10.0",
+        "uuid": "^3.4.0",
+        "websocket-driver": "0.6.5"
+      }
+    },
+    "sockjs-client": {
+      "version": "1.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sockjs-client/download/sockjs-client-1.4.0.tgz",
+      "integrity": "sha1-yfJWjhnI/YFztJl+o0IOC7MGx9U=",
+      "dev": true,
+      "requires": {
+        "debug": "^3.2.5",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "~0.11.1",
+        "inherits": "^2.0.3",
+        "json3": "^3.3.2",
+        "url-parse": "^1.4.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "faye-websocket": {
+          "version": "0.11.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/faye-websocket/download/faye-websocket-0.11.3.tgz",
+          "integrity": "sha1-XA6aiWjokSwoZjn96XeosgnyUI4=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sort-keys/download/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "source-list-map": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-list-map/download/source-list-map-2.0.1.tgz",
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
+    },
+    "source-map-resolve": {
+      "version": "0.5.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map-resolve/download/source-map-resolve-0.5.3.tgz",
+      "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.2",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
+    },
+    "source-map-support": {
+      "version": "0.5.19",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map-support/download/source-map-support-0.5.19.tgz",
+      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map-url/download/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/spdx-correct/download/spdx-correct-3.1.1.tgz",
+      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/spdx-exceptions/download/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/spdx-expression-parse/download/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/spdx-license-ids/download/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha1-yAdXODwoq/cpZ0SZjLwQaui4VM4=",
+      "dev": true
+    },
+    "spdy": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/spdy/download/spdy-4.0.2.tgz",
+      "integrity": "sha1-t09GYgOj7aRSwCSSuR+56EonZ3s=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-4.2.0.tgz",
+          "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        }
+      }
+    },
+    "spdy-transport": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/spdy-transport/download/spdy-transport-3.0.0.tgz",
+      "integrity": "sha1-ANSGOmQArXXfkzYaFghgXl3NzzE=",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-4.2.0.tgz",
+          "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/readable-stream/download/readable-stream-3.6.0.tgz",
+          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/split-string/download/split-string-3.1.0.tgz",
+      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sprintf-js/download/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/sshpk/download/sshpk-1.16.1.tgz",
+      "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "ssri": {
+      "version": "6.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ssri/download/ssri-6.0.1.tgz",
+      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+      "dev": true,
+      "requires": {
+        "figgy-pudding": "^3.5.1"
+      }
+    },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stable/download/stable-0.1.8.tgz",
+      "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stack-utils/download/stack-utils-1.0.2.tgz",
+      "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
+      "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/static-extend/download/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/define-property/download/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/statuses/download/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
+    },
+    "std-env": {
+      "version": "2.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/std-env/download/std-env-2.2.1.tgz",
+      "integrity": "sha1-L/oP3J4iY+AATBIRlm6WCUikD2s=",
+      "dev": true,
+      "requires": {
+        "ci-info": "^1.6.0"
+      }
+    },
+    "stdout-stream": {
+      "version": "1.4.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stdout-stream/download/stdout-stream-1.4.1.tgz",
+      "integrity": "sha1-WsF0zdXNcmEEqgwLK9g4FdjVNd4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      }
+    },
+    "stream-browserify": {
+      "version": "2.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stream-browserify/download/stream-browserify-2.0.2.tgz",
+      "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.1",
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-each": {
+      "version": "1.2.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stream-each/download/stream-each-1.2.3.tgz",
+      "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "stream-http": {
+      "version": "2.8.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stream-http/download/stream-http-2.8.3.tgz",
+      "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.3.6",
+        "to-arraybuffer": "^1.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stream-shift/download/stream-shift-1.0.1.tgz",
+      "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
+      "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strict-uri-encode/download/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string-width/download/string-width-3.1.0.tgz",
+      "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+      "requires": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string.prototype.trimend/download/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.17.6.tgz",
+          "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string.prototype.trimstart/download/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.17.6.tgz",
+          "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string_decoder/download/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-bom/download/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-bom-string/download/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI=",
+      "dev": true
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-eof/download/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-indent/download/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-json-comments/download/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "stylehacks": {
+      "version": "4.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stylehacks/download/stylehacks-4.0.3.tgz",
+      "integrity": "sha1-Zxj8r00eB9ihMYaQiB6NlnJqcdU=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.0.0",
+        "postcss": "^7.0.0",
+        "postcss-selector-parser": "^3.0.0"
+      },
+      "dependencies": {
+        "postcss-selector-parser": {
+          "version": "3.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/postcss-selector-parser/download/postcss-selector-parser-3.1.2.tgz",
+          "integrity": "sha1-sxD1xMD9r3b5SQK7qjDbaqhPUnA=",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
+      }
+    },
+    "stylus": {
+      "version": "0.54.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stylus/download/stylus-0.54.8.tgz",
+      "integrity": "sha1-PaPmWWa8Vnp7BEv+DuzmU+CZ0Uc=",
+      "dev": true,
+      "requires": {
+        "css-parse": "~2.0.0",
+        "debug": "~3.1.0",
+        "glob": "^7.1.6",
+        "mkdirp": "~1.0.4",
+        "safer-buffer": "^2.1.2",
+        "sax": "~1.2.4",
+        "semver": "^6.3.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/mkdirp/download/mkdirp-1.0.4.tgz",
+          "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.7.3.tgz",
+          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+          "dev": true
+        }
+      }
+    },
+    "stylus-loader": {
+      "version": "3.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/stylus-loader/download/stylus-loader-3.0.2.tgz",
+      "integrity": "sha1-J6cGQgsFo44DjnyssVNXjUUFE8Y=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "lodash.clonedeep": "^4.5.0",
+        "when": "~3.6.x"
+      }
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/svg-tags/download/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "dev": true
+    },
+    "svgo": {
+      "version": "1.3.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/svgo/download/svgo-1.3.2.tgz",
+      "integrity": "sha1-ttxRHAYzRsnkFbgeQ0ARRbltQWc=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "coa": "^2.0.2",
+        "css-select": "^2.0.0",
+        "css-select-base-adapter": "^0.1.1",
+        "css-tree": "1.0.0-alpha.37",
+        "csso": "^4.0.2",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "~0.5.1",
+        "object.values": "^1.1.0",
+        "sax": "~1.2.4",
+        "stable": "^0.1.8",
+        "unquote": "~1.1.1",
+        "util.promisify": "~1.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "tapable": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tapable/download/tapable-1.1.3.tgz",
+      "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
+      "dev": true
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tar/download/tar-2.2.2.tgz",
+      "integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
+      "dev": true,
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
+      }
+    },
+    "term-size": {
+      "version": "2.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/term-size/download/term-size-2.2.0.tgz",
+      "integrity": "sha1-Hxat7f6b3BiADhd2ghc0CG/MZ1M=",
+      "dev": true
+    },
+    "terser": {
+      "version": "4.8.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/terser/download/terser-4.8.0.tgz",
+      "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/commander/download/commander-2.20.3.tgz",
+          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "1.4.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/terser-webpack-plugin/download/terser-webpack-plugin-1.4.5.tgz",
+      "integrity": "sha1-oheu+uozDnNP+sthIOwfoxLWBAs=",
+      "dev": true,
+      "requires": {
+        "cacache": "^12.0.2",
+        "find-cache-dir": "^2.1.0",
+        "is-wsl": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^4.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^4.1.2",
+        "webpack-sources": "^1.4.0",
+        "worker-farm": "^1.7.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/text-table/download/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/through/download/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/through2/download/through2-2.0.5.tgz",
+      "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/thunky/download/thunky-1.1.0.tgz",
+      "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30=",
+      "dev": true
+    },
+    "timers-browserify": {
+      "version": "2.0.11",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/timers-browserify/download/timers-browserify-2.0.11.tgz",
+      "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
+      "dev": true,
+      "requires": {
+        "setimmediate": "^1.0.4"
+      }
+    },
+    "timsort": {
+      "version": "0.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/timsort/download/timsort-0.3.0.tgz",
+      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tiny-emitter/download/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha1-HRpW7fxRxD6GPLtTgqcjMONVVCM=",
+      "dev": true,
+      "optional": true
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-arraybuffer/download/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "to-factory": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-factory/download/to-factory-1.0.0.tgz",
+      "integrity": "sha1-hzivi9lxIK0dQEeXKtpVY7+UebE=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-fast-properties/download/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-object-path/download/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/kind-of/download/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-readable-stream": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-readable-stream/download/to-readable-stream-1.0.0.tgz",
+      "integrity": "sha1-zgqgwvPfat+FLvtASng+d8BHV3E=",
+      "dev": true
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-regex/download/to-regex-3.0.2.tgz",
+      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-regex-range/download/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/toidentifier/download/toidentifier-1.0.0.tgz",
+      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
+      "dev": true
+    },
+    "toml": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/toml/download/toml-3.0.0.tgz",
+      "integrity": "sha1-NCFg8a8ZBOydIE0DpdYSItdixe4=",
+      "dev": true
+    },
+    "toposort": {
+      "version": "1.0.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/toposort/download/toposort-1.0.7.tgz",
+      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tough-cookie/download/tough-cookie-2.5.0.tgz",
+      "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/trim-newlines/download/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "true-case-path": {
+      "version": "1.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/true-case-path/download/true-case-path-1.0.3.tgz",
+      "integrity": "sha1-+BO1qMhrQNpZYGcisUTjIleZ9H0=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.2"
+      }
+    },
+    "tslib": {
+      "version": "1.13.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tslib/download/tslib-1.13.0.tgz",
+      "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM=",
+      "dev": true
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tty-browserify/download/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tunnel-agent/download/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/tweetnacl/download/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/type-fest/download/type-fest-0.11.0.tgz",
+      "integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/type-is/download/type-is-1.6.18.tgz",
+      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/typedarray/download/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/typedarray-to-buffer/download/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/uc.micro/download/uc.micro-1.0.6.tgz",
+      "integrity": "sha1-nEEagCpAmpH8bPdAgbq6NLJEmaw=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.4.10",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/uglify-js/download/uglify-js-3.4.10.tgz",
+      "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
+      "dev": true,
+      "requires": {
+        "commander": "~2.19.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/commander/download/commander-2.19.0.tgz",
+          "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unicode-canonical-property-names-ecmascript/download/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unicode-match-property-ecmascript/download/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unicode-match-property-value-ecmascript/download/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha1-DZH2AO7rMJaqlisdb8iIduZOpTE=",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unicode-property-aliases-ecmascript/download/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ=",
+      "dev": true
+    },
+    "union-value": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/union-value/download/union-value-1.0.1.tgz",
+      "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^2.0.1"
+      }
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/uniq/download/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/uniqs/download/uniqs-2.0.0.tgz",
+      "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
+      "dev": true
+    },
+    "unique-filename": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unique-filename/download/unique-filename-1.1.1.tgz",
+      "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unique-slug/download/unique-slug-2.0.2.tgz",
+      "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unique-string/download/unique-string-2.0.0.tgz",
+      "integrity": "sha1-OcZFH4GvsnSd4rIz4/fF6IQ72J0=",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^2.0.0"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/universalify/download/universalify-0.1.2.tgz",
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unpipe/download/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unquote/download/unquote-1.1.1.tgz",
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+      "dev": true
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/unset-value/download/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-value/download/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/isobject/download/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-values/download/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        }
+      }
+    },
+    "upath": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/upath/download/upath-1.2.0.tgz",
+      "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "4.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/update-notifier/download/update-notifier-4.1.1.tgz",
+      "integrity": "sha1-iV/IViu+ZmF5UA+fLOusTyYyN0Y=",
+      "dev": true,
+      "requires": {
+        "boxen": "^4.2.0",
+        "chalk": "^3.0.0",
+        "configstore": "^5.0.1",
+        "has-yarn": "^2.1.0",
+        "import-lazy": "^2.1.0",
+        "is-ci": "^2.0.0",
+        "is-installed-globally": "^0.3.1",
+        "is-npm": "^4.0.0",
+        "is-yarn-global": "^0.3.0",
+        "latest-version": "^5.0.0",
+        "pupa": "^2.0.1",
+        "semver-diff": "^3.1.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-styles/download/ansi-styles-4.2.1.tgz",
+          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color-convert/download/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/color-name/download/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/has-flag/download/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/upper-case/download/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/uri-js/download/uri-js-4.4.0.tgz",
+      "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/urix/download/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/url/download/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/punycode/download/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "url-loader": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/url-loader/download/url-loader-1.1.2.tgz",
+      "integrity": "sha1-uXHRkbg69pPF4/6kBkvp4fLX+Ng=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "mime": "^2.0.3",
+        "schema-utils": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/url-parse/download/url-parse-1.4.7.tgz",
+      "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/url-parse-lax/download/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/use/download/use-3.1.1.tgz",
+      "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+      "dev": true
+    },
+    "util": {
+      "version": "0.11.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/util/download/util-0.11.1.tgz",
+      "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/inherits/download/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/util-deprecate/download/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/util.promisify/download/util.promisify-1.0.1.tgz",
+      "integrity": "sha1-a693dLgO6w91INi4HQeYKlmruu4=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.2",
+        "has-symbols": "^1.0.1",
+        "object.getownpropertydescriptors": "^2.1.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/es-abstract/download/es-abstract-1.17.6.tgz",
+          "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-regex": "^1.1.0",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
+      }
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/utila/download/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/utils-merge/download/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/uuid/download/uuid-3.4.0.tgz",
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/validate-npm-package-license/download/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vary/download/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "vendors": {
+      "version": "1.0.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vendors/download/vendors-1.0.4.tgz",
+      "integrity": "sha1-4rgApT56Kbk1BsPPQRANFsTErY4=",
+      "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/verror/download/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vm-browserify/download/vm-browserify-1.1.2.tgz",
+      "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
+      "dev": true
+    },
+    "vue": {
+      "version": "2.6.12",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue/download/vue-2.6.12.tgz",
+      "integrity": "sha1-9evU+mvShpQD4pqJau1JBEVskSM=",
+      "dev": true
+    },
+    "vue-hot-reload-api": {
+      "version": "2.3.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue-hot-reload-api/download/vue-hot-reload-api-2.3.4.tgz",
+      "integrity": "sha1-UylVzB6yCKPZkLOp+acFdGV+CPI=",
+      "dev": true
+    },
+    "vue-loader": {
+      "version": "15.9.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue-loader/download/vue-loader-15.9.3.tgz",
+      "integrity": "sha1-DeNdnlVdPtU5aVFsrFziVTEpndo=",
+      "dev": true,
+      "requires": {
+        "@vue/component-compiler-utils": "^3.1.0",
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.1.0",
+        "vue-hot-reload-api": "^2.3.0",
+        "vue-style-loader": "^4.1.0"
+      }
+    },
+    "vue-router": {
+      "version": "3.4.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue-router/download/vue-router-3.4.3.tgz",
+      "integrity": "sha1-+pN2hhbuM4qhdPFgrJZRZ/pXL/o=",
+      "dev": true
+    },
+    "vue-server-renderer": {
+      "version": "2.6.12",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue-server-renderer/download/vue-server-renderer-2.6.12.tgz",
+      "integrity": "sha1-qMucSUOe8gUpPLQcNdDSsFQWU6U=",
+      "dev": true,
+      "requires": {
+        "chalk": "^1.1.3",
+        "hash-sum": "^1.0.2",
+        "he": "^1.1.0",
+        "lodash.template": "^4.5.0",
+        "lodash.uniq": "^4.5.0",
+        "resolve": "^1.2.0",
+        "serialize-javascript": "^3.1.0",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "serialize-javascript": {
+          "version": "3.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/serialize-javascript/download/serialize-javascript-3.1.0.tgz",
+          "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        }
+      }
+    },
+    "vue-style-loader": {
+      "version": "4.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue-style-loader/download/vue-style-loader-4.1.2.tgz",
+      "integrity": "sha1-3t80mAbyXOtOZPOtfApE+6c1/Pg=",
+      "dev": true,
+      "requires": {
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.0.2"
+      }
+    },
+    "vue-template-compiler": {
+      "version": "2.6.12",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue-template-compiler/download/vue-template-compiler-2.6.12.tgz",
+      "integrity": "sha1-lH7XGWdEyKUoXr4SM/6WBDf8xX4=",
+      "dev": true,
+      "requires": {
+        "de-indent": "^1.0.2",
+        "he": "^1.1.0"
+      }
+    },
+    "vue-template-es2015-compiler": {
+      "version": "1.9.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vue-template-es2015-compiler/download/vue-template-es2015-compiler-1.9.1.tgz",
+      "integrity": "sha1-HuO8mhbsv1EYvjNLsV+cRvgvWCU=",
+      "dev": true
+    },
+    "vuepress": {
+      "version": "1.5.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vuepress/download/vuepress-1.5.4.tgz",
+      "integrity": "sha1-KC0kEsHHJp2L2TuD1CHvU7d7RfY=",
+      "dev": true,
+      "requires": {
+        "@vuepress/core": "1.5.4",
+        "@vuepress/theme-default": "1.5.4",
+        "cac": "^6.5.6",
+        "envinfo": "^7.2.0",
+        "opencollective-postinstall": "^2.0.2",
+        "update-notifier": "^4.0.0"
+      }
+    },
+    "vuepress-html-webpack-plugin": {
+      "version": "3.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vuepress-html-webpack-plugin/download/vuepress-html-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha1-IZvicq1RD6qHUNLU5w/QKL/RwW4=",
+      "dev": true,
+      "requires": {
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "tapable": "^1.0.0",
+        "toposort": "^1.0.0",
+        "util.promisify": "1.0.0"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "3.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/big.js/download/big.js-3.2.0.tgz",
+          "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
+          "dev": true
+        },
+        "emojis-list": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/emojis-list/download/emojis-list-2.1.0.tgz",
+          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+          "dev": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/json5/download/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/loader-utils/download/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "util.promisify": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/util.promisify/download/util.promisify-1.0.0.tgz",
+          "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "object.getownpropertydescriptors": "^2.0.3"
+          }
+        }
+      }
+    },
+    "vuepress-plugin-container": {
+      "version": "2.1.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vuepress-plugin-container/download/vuepress-plugin-container-2.1.5.tgz",
+      "integrity": "sha1-N//wVmL+29Y//TpUY7JZLHp/MTM=",
+      "dev": true,
+      "requires": {
+        "@vuepress/shared-utils": "^1.2.0",
+        "markdown-it-container": "^2.0.0"
+      }
+    },
+    "vuepress-plugin-smooth-scroll": {
+      "version": "0.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/vuepress-plugin-smooth-scroll/download/vuepress-plugin-smooth-scroll-0.0.3.tgz",
+      "integrity": "sha1-bv8tTBhsypF8yfffKwr33nyMZDg=",
+      "dev": true,
+      "requires": {
+        "smoothscroll-polyfill": "^0.4.3"
+      }
+    },
+    "watchpack": {
+      "version": "1.7.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/watchpack/download/watchpack-1.7.4.tgz",
+      "integrity": "sha1-bp2lOzyAuy1lCBiPWyAEEIZs0ws=",
+      "dev": true,
+      "requires": {
+        "chokidar": "^3.4.1",
+        "graceful-fs": "^4.1.2",
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/anymatch/download/anymatch-3.1.1.tgz",
+          "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/binary-extensions/download/binary-extensions-2.1.0.tgz",
+          "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/braces/download/braces-3.0.2.tgz",
+          "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chokidar/download/chokidar-3.4.2.tgz",
+          "integrity": "sha1-ONyOZY3sOAl0HrPve7Ckf+QkIy0=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fill-range/download/fill-range-7.0.1.tgz",
+          "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/fsevents/download/fsevents-2.1.3.tgz",
+          "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+          "dev": true,
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/glob-parent/download/glob-parent-5.1.1.tgz",
+          "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-binary-path/download/is-binary-path-2.1.0.tgz",
+          "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-number/download/is-number-7.0.0.tgz",
+          "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+          "dev": true,
+          "optional": true
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/readdirp/download/readdirp-3.4.0.tgz",
+          "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/to-regex-range/download/to-regex-range-5.0.1.tgz",
+          "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/watchpack-chokidar2/download/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha1-mUihhmy71suCTeoTp+1pH2yN3/A=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/wbuf/download/wbuf-1.7.3.tgz",
+      "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "webpack": {
+      "version": "4.44.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack/download/webpack-4.44.2.tgz",
+      "integrity": "sha1-a/4rCvBVyLLR6Q7SzZNj+EEma3I=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/ast": "1.9.0",
+        "@webassemblyjs/helper-module-context": "1.9.0",
+        "@webassemblyjs/wasm-edit": "1.9.0",
+        "@webassemblyjs/wasm-parser": "1.9.0",
+        "acorn": "^6.4.1",
+        "ajv": "^6.10.2",
+        "ajv-keywords": "^3.4.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^4.3.0",
+        "eslint-scope": "^4.0.3",
+        "json-parse-better-errors": "^1.0.2",
+        "loader-runner": "^2.4.0",
+        "loader-utils": "^1.2.3",
+        "memory-fs": "^0.4.1",
+        "micromatch": "^3.1.10",
+        "mkdirp": "^0.5.3",
+        "neo-async": "^2.6.1",
+        "node-libs-browser": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.1.3",
+        "terser-webpack-plugin": "^1.4.3",
+        "watchpack": "^1.7.4",
+        "webpack-sources": "^1.4.1"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
+    "webpack-chain": {
+      "version": "6.5.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack-chain/download/webpack-chain-6.5.1.tgz",
+      "integrity": "sha1-TycoTLu2N+PI+970Pu9YjU2GEgY=",
+      "dev": true,
+      "requires": {
+        "deepmerge": "^1.5.2",
+        "javascript-stringify": "^2.0.1"
+      },
+      "dependencies": {
+        "javascript-stringify": {
+          "version": "2.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/javascript-stringify/download/javascript-stringify-2.0.1.tgz",
+          "integrity": "sha1-bvNYA1MQ411mfGde1j0+t8GqGeU=",
+          "dev": true
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "3.7.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack-dev-middleware/download/webpack-dev-middleware-3.7.2.tgz",
+      "integrity": "sha1-ABnD23FuP6XOy/ZPKriKdLqzMfM=",
+      "dev": true,
+      "requires": {
+        "memory-fs": "^0.4.1",
+        "mime": "^2.4.4",
+        "mkdirp": "^0.5.1",
+        "range-parser": "^1.2.1",
+        "webpack-log": "^2.0.0"
+      }
+    },
+    "webpack-dev-server": {
+      "version": "3.11.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack-dev-server/download/webpack-dev-server-3.11.0.tgz",
+      "integrity": "sha1-jxVKO84bz9HMYY705wMniFXn/4w=",
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "bonjour": "^3.5.0",
+        "chokidar": "^2.1.8",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "debug": "^4.1.1",
+        "del": "^4.1.1",
+        "express": "^4.17.1",
+        "html-entities": "^1.3.1",
+        "http-proxy-middleware": "0.19.1",
+        "import-local": "^2.0.0",
+        "internal-ip": "^4.3.0",
+        "ip": "^1.1.5",
+        "is-absolute-url": "^3.0.3",
+        "killable": "^1.0.1",
+        "loglevel": "^1.6.8",
+        "opn": "^5.5.0",
+        "p-retry": "^3.0.1",
+        "portfinder": "^1.0.26",
+        "schema-utils": "^1.0.0",
+        "selfsigned": "^1.10.7",
+        "semver": "^6.3.0",
+        "serve-index": "^1.9.1",
+        "sockjs": "0.3.20",
+        "sockjs-client": "1.4.0",
+        "spdy": "^4.0.2",
+        "strip-ansi": "^3.0.1",
+        "supports-color": "^6.1.0",
+        "url": "^0.11.0",
+        "webpack-dev-middleware": "^3.7.2",
+        "webpack-log": "^2.0.0",
+        "ws": "^6.2.1",
+        "yargs": "^13.3.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/debug/download/debug-4.2.0.tgz",
+          "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "is-absolute-url": {
+          "version": "3.0.3",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-absolute-url/download/is-absolute-url-3.0.3.tgz",
+          "integrity": "sha1-lsaiK2ojkpsR6gr7GDbDatSl1pg=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ms/download/ms-2.1.2.tgz",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "1.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/schema-utils/download/schema-utils-1.0.0.tgz",
+          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/semver/download/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yargs/download/yargs-13.3.2.tgz",
+          "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yargs-parser/download/yargs-parser-13.1.2.tgz",
+          "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "webpack-log": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack-log/download/webpack-log-2.0.0.tgz",
+      "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^3.0.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "webpack-merge": {
+      "version": "4.2.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack-merge/download/webpack-merge-4.2.2.tgz",
+      "integrity": "sha1-onxS6ng9E5iv0gh/VH17nS9DY00=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
+    "webpack-sources": {
+      "version": "1.4.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpack-sources/download/webpack-sources-1.4.3.tgz",
+      "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "^2.0.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/source-map/download/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "webpackbar": {
+      "version": "3.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/webpackbar/download/webpackbar-3.2.0.tgz",
+      "integrity": "sha1-varRA/rRGk5hJQDnKqrpiwi6ST8=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.1.0",
+        "chalk": "^2.4.1",
+        "consola": "^2.6.0",
+        "figures": "^3.0.0",
+        "pretty-time": "^1.1.0",
+        "std-env": "^2.2.1",
+        "text-table": "^0.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/chalk/download/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/supports-color/download/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "websocket-driver": {
+      "version": "0.6.5",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/websocket-driver/download/websocket-driver-0.6.5.tgz",
+      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+      "dev": true,
+      "requires": {
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/websocket-extensions/download/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI=",
+      "dev": true
+    },
+    "when": {
+      "version": "3.6.4",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/when/download/when-3.6.4.tgz",
+      "integrity": "sha1-RztRfsFZ4rhQBUl6E5g/CVQS404=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/which/download/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/which-module/download/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/wide-align/download/wide-align-1.1.3.tgz",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string-width/download/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "widest-line": {
+      "version": "3.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/widest-line/download/widest-line-3.1.0.tgz",
+      "integrity": "sha1-gpIzO79my0X/DeFgOxNreuFJbso=",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ansi-regex/download/ansi-regex-5.0.0.tgz",
+          "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/emoji-regex/download/emoji-regex-8.0.0.tgz",
+          "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/is-fullwidth-code-point/download/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/string-width/download/string-width-4.2.0.tgz",
+          "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/strip-ansi/download/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
+    "worker-farm": {
+      "version": "1.7.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/worker-farm/download/worker-farm-1.7.0.tgz",
+      "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.7"
+      }
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/wrap-ansi/download/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/wrappy/download/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/write-file-atomic/download/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha1-Vr1cWlxwSBzRnFcb05q5ZaXeVug=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "6.2.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/ws/download/ws-6.2.1.tgz",
+      "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/xdg-basedir/download/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha1-S8jZmEQDaWIl74OhVzy7y0552xM=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/xtend/download/xtend-4.0.2.tgz",
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+      "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/y18n/download/y18n-4.0.0.tgz",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yallist/download/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "14.2.3",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yargs/download/yargs-14.2.3.tgz",
+      "integrity": "sha1-Ghw+3O0a+yov6jNgS8bR2NaIpBQ=",
+      "requires": {
+        "cliui": "^5.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^15.0.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "15.0.1",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/yargs-parser/download/yargs-parser-15.0.1.tgz",
+      "integrity": "sha1-VHhq9AuCDcsvuAJbEbTWWddjI7M=",
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "zepto": {
+      "version": "1.2.0",
+      "resolved": "http://artifactory.intra.xiaojukeji.com:80/artifactory/api/npm/npm/zepto/download/zepto-1.2.0.tgz",
+      "integrity": "sha1-4Se9nmb9hGvl6rSME5SIL3wOT5g=",
+      "dev": true
+    }
+  }
+}

--- a/src/guide/migration/render-function-api.md
+++ b/src/guide/migration/render-function-api.md
@@ -128,6 +128,47 @@ In 3.x, the entire VNode props structure is flattened. Using the example from ab
 }
 ```
 
+## Registered Component
+
+### 2.x Syntax
+
+In 2.x, when a component has been registered, the render function will work well when passing the component's name as string to the first arguments:
+
+```js
+// 2.x
+Vue.component('button-counter', {
+  data: () => ({
+    count: 0
+  }),
+  template: '<button @click="count++">Clicked {{ count }} times.</button>'
+})
+
+export default {
+  render(h) {
+    return h('button-counter')
+  }
+}
+```
+
+### 3.x Syntax
+
+In 3.x, with VNodes being context-free, we can no longer use a string ID to implicitly lookup registered components. Instead, we need to use an imported API:
+
+```js
+// 3.x
+import { h, resolveComponent } from 'vue'
+
+const ButtonCounter = resolveComponent('button-counter')
+
+export default {
+  setup() {
+    return () => h(ButtonCounter)
+  }
+}
+```
+
+For more information, see [The Render Function Api Change RFC](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0008-render-function-api-change.md#context-free-vnodes).
+
 ## Migration Strategy
 
 ### Library Authors

--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -394,8 +394,10 @@ render() {
 If we're writing a lot of `render` functions, it might feel painful to write something like this:
 
 ```js
+import { resolveComponent } from 'vue'
+
 Vue.h(
-  'anchored-heading',
+  resolveComponent('anchored-heading'),
   {
     level: 1
   },


### PR DESCRIPTION
## Description of Problem
In v3.x, `h` now no longer use a string ID (e.g. h('some-component')) to implicitly lookup globally registered components. It may explicitly show on the Migration Guide Docs.

## Proposed Solution
Update the Migration Guide.

## Additional Information
