### PR TITLE
add staticClass and style to migration guide

### DIFF
--- a/src/guide/migration/render-function-api.md
+++ b/src/guide/migration/render-function-api.md
@@ -103,8 +103,10 @@ In 2.x, `domProps` contained a nested list within the VNode props:
 ```js
 // 2.x
 {
-  class: ['button', 'is-outlined'],
-  style: { color: '#34495E' },
+  staticClass: 'button',
+  class: {'is-outlined': isOutlined },
+  staticStyle: { color: '#34495E' },
+  style: { backgroundColor: buttonColor },
   attrs: { id: 'submit' },
   domProps: { innerHTML: '' },
   on: { click: submitForm },
@@ -119,8 +121,8 @@ In 3.x, the entire VNode props structure is flattened. Using the example from ab
 ```js
 // 3.x Syntax
 {
-  class: ['button', 'is-outlined'],
-  style: { color: '#34495E' },
+  class: ['button', { 'is-outlined': isOutlined }],
+  style: [{ color: '#34495E' }, { backgroundColor: buttonColor }],
   id: 'submit',
   innerHTML: '',
   onClick: submitForm,


### PR DESCRIPTION
From vuejs/vue-next#2248

## Description of Problem

Missing some information for vnode structure migration

## Proposed Solution

Adding example about staticClass and staticStyle

## Additional Information

[Vue 3](https://vue-next-template-explorer.netlify.app/#%7B%22src%22%3A%22%3Cdiv%20class%3D%5C%22button%5C%22%20%3Aclass%3D%5C%22%7B%20isOutlined%20%7D%5C%22%20style%3D%5C%22color%3A%20red%3B%5C%22%20%3Astyle%3D%5C%22%7B%20color%3A%20'blue'%20%7D%5C%22%3E%7B%7B%20cart.items%20%7D%7D%3C%2Fdiv%3E%22%2C%22ssr%22%3Atrue%2C%22options%22%3A%7B%22mode%22%3A%22module%22%2C%22prefixIdentifiers%22%3Afalse%2C%22optimizeImports%22%3Afalse%2C%22hoistStatic%22%3Afalse%2C%22cacheHandlers%22%3Afalse%2C%22scopeId%22%3Anull%2C%22ssrCssVars%22%3A%22%7B%20color%20%7D%22%2C%22bindingMetadata%22%3A%7B%22TestComponent%22%3A%22setup%22%2C%22foo%22%3A%22setup%22%2C%22bar%22%3A%22props%22%7D%2C%22optimizeBindings%22%3Afalse%7D%7D)
[Vue 2](https://template-explorer.vuejs.org/#%3Cdiv%20class%3D%22button%22%20%3Aclass%3D%22%7B%20isOutlined%20%7D%22%20style%3D%22color%3A%20red%3B%22%20%3Astyle%3D%22%7B%20color%3A%20'blue'%20%7D%22%3E%7B%7B%20cart.items%20%7D%7D%3C%2Fdiv%3E)
