### PR TITLE
Correct typo in "Single file components" reference

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -53,7 +53,7 @@ Make sure that `script` part of the component has TypeScript set as a language:
 
 ### Editor Support
 
-For developing Vue applications with TypeScript, we strongly recommend using [Visual Studio Code](https://code.visualstudio.com/), which provides great out-of-the-box support for TypeScript. If you are using [single-file components](./single-file-components.html) (SFCs), get the awesome [Vetur extension](https://github.com/vuejs/vetur), which provides TypeScript inference inside SFCs and many other great features.
+For developing Vue applications with TypeScript, we strongly recommend using [Visual Studio Code](https://code.visualstudio.com/), which provides great out-of-the-box support for TypeScript. If you are using [single-file components](./single-file-component.html) (SFCs), get the awesome [Vetur extension](https://github.com/vuejs/vetur), which provides TypeScript inference inside SFCs and many other great features.
 
 [WebStorm](https://www.jetbrains.com/webstorm/) also provides out-of-the-box support for both TypeScript and Vue.
 


### PR DESCRIPTION
## Description of Problem
Current link to "Single file components" from the Typescript support page does not point to the correct location.

## Proposed Solution
Update the "Single file components" reference to point to the correct path.

## Additional Information
