### PR TITLE
Remove blank lines from an example that shouldn't have them

### DIFF
--- a/src/style-guide/README.md
+++ b/src/style-guide/README.md
@@ -1402,21 +1402,17 @@ props: {
     type: String,
     required: true
   },
-
   focused: {
     type: Boolean,
     default: false
   },
-
   label: String,
   icon: String
 },
-
 computed: {
   formattedValue() {
     // ...
   },
-
   inputClasses() {
     // ...
   }


### PR DESCRIPTION
## Description of Problem

The style guide has an example intended to show component options without blank lines between them.

This example acquired blank lines during the migration to Vue 3, so it no longer makes sense.

## Proposed Solution

I have removed the blank lines to match the Vue 2 example.

## Additional Information

See the second example in:

Vue 2: https://vuejs.org/v2/style-guide/#Empty-lines-in-component-instance-options-recommended
Vue 3: https://v3.vuejs.org/style-guide/#empty-lines-in-component-instance-options-recommended