### PR TITLE
fix:fix a broken link

### DIFF
--- a/src/guide/component-edge-cases.md
+++ b/src/guide/component-edge-cases.md
@@ -1,6 +1,6 @@
 # Handling Edge Cases
 
-> This page assumes you've already read the [Components Basics](components.md). Read that first if you are new to components.
+> This page assumes you've already read the [Components Basics](component-basics.md). Read that first if you are new to components.
 
 :::tip Note
 All the features on this page document the handling of edge cases, meaning unusual situations that sometimes require bending Vue's rules a little. Note however, that they all have disadvantages or situations where they could be dangerous. These are noted in each case, so keep them in mind when deciding to use each feature.


### PR DESCRIPTION
## Description of Problem
In [Handling Edge Cases](https://vue3js.cn/docs/guide/component-edge-cases.html#controlling-updates) page, the link of "Components Basics" has broken and redirect to the 404 page.

The reason is that the link file name of "Components Basics" is not existed. The right name should be "component-basics.md"

## Proposed Solution
Change the link file name from "components.md" to "component-basics.md"

## Additional Information
In [Dynamic & Async Components](https://vue3js.cn/docs/guide/component-dynamic-async.html#dynamic-components-with-keep-alive) page, "Components Basics" also has a broken link, but I find nothing wrong with the code. 
