### PR TITLE
fix(docs): inject key is the provide key

### DIFF
--- a/src/guide/composition-api-provide-inject.md
+++ b/src/guide/composition-api-provide-inject.md
@@ -36,7 +36,7 @@ export default {
 <!-- src/components/MyMarker.vue -->
 <script>
 export default {
-  inject: ['location', 'longitude', 'latitude']
+  inject: ['location', 'geolocation']
 }
 </script>
 ```


### PR DESCRIPTION
## Description of Problem

the key of inject is non-existent

```vue
<!-- src/components/MyMap.vue -->
<template>
  <MyMarker />
</template>

<script>
import MyMarker from './MyMarker.vue'

export default {
  components: {
    MyMarker
  },
  provide: {
    location: 'North Pole',
    geolocation: {
      longitude: 90,
      latitude: 135
    }
  }
}
</script>
```

```vue
<!-- src/components/MyMarker.vue -->
<script>
export default {
  inject: ['location', 'longitude', 'latitude'] // it is wrong
  // inject: ['location', 'geolocation'] // it is correct
}
</script>
```
