### PR TITLE
fix, minor grammar. first-class citizen

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -4,7 +4,7 @@
 
 ## Official Declaration in NPM Packages
 
-A static type system can help prevent many potential runtime errors as applications grow, which is why Vue 3 is written in TypeScript. This means you don't need any additional tooling to use TypeScript with Vue - it has a first-class citizens' support.
+A static type system can help prevent many potential runtime errors as applications grow, which is why Vue 3 is written in TypeScript. This means you don't need any additional tooling to use TypeScript with Vue - it has first-class citizen support.
 
 ## Recommended Configuration
 

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -4,7 +4,7 @@
 
 ## Official Declaration in NPM Packages
 
-A static type system can help prevent many potential runtime errors as applications grow, which is why Vue 3 is written in TypeScript. This means you don't need any additional tooling to use TypeScript with Vue - it has a first-class citizen support.
+A static type system can help prevent many potential runtime errors as applications grow, which is why Vue 3 is written in TypeScript. This means you don't need any additional tooling to use TypeScript with Vue - it has a first-class citizens' support.
 
 ## Recommended Configuration
 


### PR DESCRIPTION
## Description of Problem
From typescript-support.md:
`This means you don't need any additional tooling to use TypeScript with Vue - it has a first-class citizen support.`

I'd think that 'It has a [...] support.' does not sound right here.

## Proposed Solution
So either; 1) *It has a first-class citizens' support*, or 2) *It has first-class citizen support* may fit better?
Option 2) technically means that first-class citizens support it. So I'd guess option 1) is the way to go.

## Additional Information
I'm not a native english speaker, so forgive me for wasting your time if I'm wrong altogether.
Cheers!