### PR TITLE
fix(style-guide): add Priority D heading

### DIFF
--- a/src/style-guide/README.md
+++ b/src/style-guide/README.md
@@ -1474,6 +1474,8 @@ computed: {
 ```
 </div>
 
+## Priority D Rules: Use with Caution <span class="hide-from-sidebar">(Potentially Dangerous Patterns)</span>
+
 ### Element selectors with `scoped` <sup data-p="d">use with caution</sup>
 
 **Element selectors should be avoided with `scoped`.**


### PR DESCRIPTION
## Description of Problem
The heading for Priority D rules in the Style Guide is missing.

## Proposed Solution
Add the heading for Priority D rules.

## Additional Information
Closes #578.
