### PR TITLE
Change version of eslint-plugin-vue

### DIFF
--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -158,7 +158,7 @@ It is recommended to use [VSCode](https://code.visualstudio.com/) with our offic
 | Project               | NPM                           | Repo                 |
 | --------------------- | ----------------------------- | -------------------- |
 | @vue/babel-plugin-jsx | [![rc][jsx-badge]][jsx-npm]   | [[GitHub][jsx-code]] |
-| eslint-plugin-vue     | [![beta][epv-badge]][epv-npm] | [[GitHub][epv-code]] |
+| eslint-plugin-vue     | [![ga][epv-badge]][epv-npm]   | [[GitHub][epv-code]] |
 | @vue/test-utils       | [![beta][vtu-badge]][vtu-npm] | [[GitHub][vtu-code]] |
 | vue-class-component   | [![beta][vcc-badge]][vcc-npm] | [[GitHub][vcc-code]] |
 | vue-loader            | [![beta][vl-badge]][vl-npm]   | [[GitHub][vl-code]]  |
@@ -170,8 +170,8 @@ It is recommended to use [VSCode](https://code.visualstudio.com/) with our offic
 [vd-badge]: https://img.shields.io/npm/v/@vue/devtools/beta.svg
 [vd-npm]: https://www.npmjs.com/package/@vue/devtools/v/beta
 [vd-code]: https://github.com/vuejs/vue-devtools/tree/next
-[epv-badge]: https://img.shields.io/npm/v/eslint-plugin-vue/next.svg
-[epv-npm]: https://www.npmjs.com/package/eslint-plugin-vue/v/next
+[epv-badge]: https://img.shields.io/npm/v/eslint-plugin-vue.svg
+[epv-npm]: https://www.npmjs.com/package/eslint-plugin-vue
 [epv-code]: https://github.com/vuejs/eslint-plugin-vue
 [vtu-badge]: https://img.shields.io/npm/v/@vue/test-utils/next.svg
 [vtu-npm]: https://www.npmjs.com/package/@vue/test-utils/v/next


### PR DESCRIPTION
## Description of Problem

I released eslint-plugin-vue@7.0.0.
But the version of eslint-plugin-vue is listed as `next` in the documentation.

## Proposed Solution

Change the version of eslint-plugin-vue described in the documentation.

## Additional Information.

https://github.com/vuejs/eslint-plugin-vue/releases/tag/v7.0.0
https://www.npmjs.com/package/eslint-plugin-vue