### PR TITLE
Use 'let' in an unwatch example as 'const' causes an error

### DIFF
--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -158,7 +158,9 @@
   If you still want to call an unwatch function inside the callback, you should check its availability first:
 
   ```js
-  const unwatch = vm.$watch(
+  let unwatch = null
+  
+  unwatch = vm.$watch(
     'value',
     function() {
       doSomething()


### PR DESCRIPTION
## Description of Problem

One of the examples uses `const` to declare `unwatch`, which causes a `ReferenceError` to be thrown.

## Proposed Solution

Use `let`, initialised on a separate line.

## Additional Information

Closes #575.