### PR TITLE
Remove references to '2.6.0+'

### DIFF
--- a/src/api/directives.md
+++ b/src/api/directives.md
@@ -197,7 +197,7 @@
   <!-- shorthand -->
   <button @click="doThis"></button>
 
-  <!-- shorthand dynamic event (2.6.0+) -->
+  <!-- shorthand dynamic event -->
   <button @[event]="doThis"></button>
 
   <!-- stop propagation -->

--- a/src/guide/template-syntax.md
+++ b/src/guide/template-syntax.md
@@ -169,7 +169,7 @@ The `v-` prefix serves as a visual cue for identifying Vue-specific attributes i
 <!-- shorthand -->
 <a @click="doSomething"> ... </a>
 
-<!-- shorthand with dynamic argument (2.6.0+) -->
+<!-- shorthand with dynamic argument -->
 <a @[event]="doSomething"> ... </a>
 ```
 


### PR DESCRIPTION
## Description of Problem

A couple of the examples for events still refer to `2.6.0+`. That makes sense in the Vue 2 docs but is unnecessary in the Vue 3 docs.

I believe these are the only remaining references of this kind.

## Proposed Solution

Removed the `2.6.0+`.