### PR TITLE
docs: fix example in component-slots.md

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -263,7 +263,7 @@ To make `item` available to the slot content provided by the parent, we can add 
 ```html
 <ul>
   <li v-for="( item, index ) in items">
-    <slot v-bind:item="item"></slot>
+    <slot :item="item"></slot>
   </li>
 </ul>
 ```


### PR DESCRIPTION
Consistent binding with image `/images/scoped-slot.png`
