### PR TITLE
feat(migration-guide): add global filters

### DIFF
--- a/src/guide/migration/filters.md
+++ b/src/guide/migration/filters.md
@@ -72,3 +72,31 @@ Using the example above, here is one example of how it could be implemented.
 ## Migration Strategy
 
 Instead of using filters, we recommend replacing them with computed properties or methods.
+
+### Global Filters
+
+If you are using filters that were globally registered and then used throughout our app, it's likely not convenient to replace them with computed props or methods in each individual component.
+
+Instead, you can make your global filters available to all components through `app.globalProperties`:
+
+```javascript
+// main.js
+const app = createApp(App)
+
+app.config.globalProperties.$filters = {
+  accountInUSD(num) {
+    return '$' + num
+  }
+}
+```
+
+Then you can fix all templates using this `$filters` object like this:
+
+```html
+<template>
+  <h1>Bank Account Balance</h1>
+  <p>{{ $filters.accountInUSD(accountInUSD) }}</p>
+</template>
+```
+
+Note that with this approach, you can only use methods, not computed properties, as the latter only make sense when defined in the context of an individual component.


### PR DESCRIPTION
## Description of Problem

The Migration strategy for filters was a little short and specifically did not help users with migrating their global filters.

## Proposed Solution

Give users guidance how to migrate globally registered filters with `app.config.globalProperties` 


## Additional Information
