### PR TITLE
Explain $el for fragments

### DIFF
--- a/src/api/instance-properties.md
+++ b/src/api/instance-properties.md
@@ -28,6 +28,8 @@
 
   The root DOM element that the component instance is managing.
 
+  For components using [fragments](../guide/migration/fragments), `$el` will be the placeholder DOM node that Vue uses to keep track of the component's position in the DOM. It is recommended to use [template refs](../guide/component-template-refs.html) for direct access to DOM elements instead of relying on `$el`.
+
 ## $options
 
 - **Type:** `Object`


### PR DESCRIPTION
## Description of Problem

The API reference entry for `$el` doesn't acknowledge fragments.

## Proposed Solution

Added an explanation for fragments.

Something similar happens for components that don't render anything due to a root-level `v-if`. I originally intended to mention that too but it just made it harder to understand.

## Additional Information

The recommendation to use template refs is taken from this RFC:

https://github.com/vuejs/rfcs/blob/master/active-rfcs/0009-global-api-change.md#mounting-behavior-difference-from-2x