### PR TITLE
Typo in the custom events page

### DIFF
--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -33,7 +33,7 @@ app.component('custom-form', {
 })
 ```
 
-In the event a native event (e.g., `click`) is defined in the `emits` option, it will be overwritten by the event in the component instead of being treated as a native listener.
+If the event a native event (e.g., `click`) is defined in the `emits` option, it will be overwritten by the event in the component instead of being treated as a native listener.
 
 ::: tip
 It is recommended to define all emitted events in order to better document how a component should work.


### PR DESCRIPTION
## Description of Problem

There is a typo in the Defining Custom Events section of component-custom-events page

## Proposed Solution

Fixed the typo :)

## Additional Information

None