### PR TITLE
Minor edit to paragraph in Custom Events section

### DIFF
--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -33,7 +33,7 @@ app.component('custom-form', {
 })
 ```
 
-In the event a native event (e.g., `click`) is defined in the `emits` option, it will be overwritten by the event in the component instead of being treated as a native listener.
+When a native event (e.g., `click`) is defined in the `emits` option, the component event will be used __instead__ of the native one.
 
 ::: tip
 It is recommended to define all emitted events in order to better document how a component should work.

--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -33,7 +33,7 @@ app.component('custom-form', {
 })
 ```
 
-When a native event (e.g., `click`) is defined in the `emits` option, the component event will be used __instead__ of the native one.
+When a native event (e.g., `click`) is defined in the `emits` option, the component event will be used __instead__ of a native event listener.
 
 ::: tip
 It is recommended to define all emitted events in order to better document how a component should work.


### PR DESCRIPTION
## Description of Problem

Starting the paragraph with _In the event_ might cause confusion, since the paragraph is discussing component events vs native events.

## Proposed Solution

Avoid using _In the event_, and use _When_ instead.

## Additional Information

We can also emphasize that the native event listener will not be used.
