### PR TITLE
fix: correct link casing

### DIFF
--- a/src/style-guide/README.md
+++ b/src/style-guide/README.md
@@ -892,7 +892,7 @@ In JavaScript, PascalCase is the convention for classes and prototype constructo
 However, for applications that use **only** global component definitions via `app.component`, we recommend kebab-case instead. The reasons are:
 
 - It's rare that global components are ever referenced in JavaScript, so following a convention for JavaScript makes less sense.
-- These applications always include many in-DOM templates, where [kebab-case **must** be used](#Component-name-casing-in-templates-strongly-recommended).
+- These applications always include many in-DOM templates, where [kebab-case **must** be used](#component-name-casing-in-templates-strongly-recommended).
 :::
 
 <div class="style-example style-example-bad">


### PR DESCRIPTION
## Description of Problem
There is wrong casing in a link.
## Proposed Solution
Fixed casing.
## Additional Information
None.