### PR TITLE
fix: remove parentheses from the video player configuration

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -254,10 +254,10 @@ module.exports = {
     ],
     ['meta', { name: 'msapplication-TileColor', content: '#000000' }],
     [
-      ('script',
+      'script',
       {
         src: 'https://player.vimeo.com/api/player.js'
-      })
+      }
     ],
     [
       'script',


### PR DESCRIPTION
## Description of Problem

Every page of the docs has `<[object Object]>` at the top. Most of the time you can't see it. It's easiest to see on the 404 page, e.g. https://v3.vuejs.org/404

---

![404 screenshot](https://user-images.githubusercontent.com/65301168/95830013-efeee680-0d2e-11eb-8504-8ba06a94b3e9.png)

---

As noted in #556, it can also be seen on other pages using some mobile browsers.

## Proposed Solution

Example: https://deploy-preview-622--vue-docs-next-preview.netlify.app/404

It is caused by a pair of parentheses in `config.js`:

```js
[
  ('script',
  {
    src: 'https://player.vimeo.com/api/player.js'
  })
],
```

In this PR I have removed those parentheses.

I am unclear whether this is the correct fix. Whatever that configuration setting was supposed to do, it doesn't seem to matter that it wasn't working. It may be that it can be removed instead.

## Additional Information

That section of the configuration was originally introduced by @phanan in #71. At that point it didn't have the parentheses. Effectively I am restoring the configuration to how it was at that point.

The parentheses were added in #543. I can't see anything in that PR that indicates that this was an intentional change.

Does anyone have a clear idea why that section is needed at all?