### PR TITLE
fix: remove NavBar CSS that was interfering with algolia

### DIFF
--- a/src/.vuepress/theme/components/Navbar.vue
+++ b/src/.vuepress/theme/components/Navbar.vue
@@ -108,7 +108,7 @@ $navbar-horizontal-padding = 1.5rem;
   padding: $navbar-vertical-padding $navbar-horizontal-padding;
   line-height: $navbarHeight - 1.4rem;
 
-  a, span, img {
+  a, img {
     display: inline-block;
   }
 


### PR DESCRIPTION
## Description of Problem

Originally reported in #556, there's an vertical alignment problem with the text of the 'buttons' in the search box. The specifics vary depending on the platform but here's an example:

![text alignment](https://user-images.githubusercontent.com/65301168/96106289-f4540480-0ed2-11eb-8874-1f9f669f736e.png)

The text is supposed to be central but instead it's at the top of the buttons.

Further, on small screens the search box is supposed to hide those buttons but currently it does not.

Both problems are caused by the same CSS. `NavBar.vue` sets `display: inline-block` for all descendent `<span>` elements, which includes the search box.

## Proposed Solution

I have removed the relevant CSS.

Testing across various platforms I wasn't able to see any visible change to the `NavBar`, aside from the desired changes to the search box. The various `<span>` elements are now a few pixels shorter but that change isn't visible and I don't believe it impacts the clickable area of the surrounding elements.

## Additional Information

There are other problems with that header in narrowish viewports. Content starts overlapping long before the media query breakpoints kick in. That isn't directly related to this change so I haven't attempted a fix here.