### PR TITLE
fix: resolve Subscribe button styling problems on Safari and Edge

### DIFF
--- a/src/.vuepress/theme/components/Newsletter.vue
+++ b/src/.vuepress/theme/components/Newsletter.vue
@@ -71,7 +71,7 @@
     position: absolute;
     padding: 4px 20px;
     margin: 0;
-    min-height: calc(100% - 8px);
+    height: calc(100% - 8px);
     right: 4px;
     top: 4px;
     font-size: 1.05em;
@@ -84,6 +84,7 @@
     transition: all 0.15s ease;
     box-sizing: border-box;
     border: 1px solid currentColor;
+    appearance: none;
   }
 }
 </style>


### PR DESCRIPTION
## Description of Problem

The original problem was reported in #556. On iOS, the Subscribe button was too short and has a gradient background.

There was an attempt at fixing the height in #625 but that has introduced problems in OSX Safari and recent versions of Edge.

**iOS - the height has been fixed but the gradient remains:**

![gradient](https://user-images.githubusercontent.com/65301168/96108453-7f35fe80-0ed5-11eb-8ec8-c3347b6987ed.png)

**Safari (same as Edge):**

![subscribe height](https://user-images.githubusercontent.com/65301168/96108397-6d545b80-0ed5-11eb-9ab6-19bda4519352.png)

The original fix changed `height` to `min-height`. The problem on Safari/Edge is that the button's default height is too large, so a `min-height` doesn't do anything.

## Proposed Solution

I believe the original problems can both be fixed using `appearance: none`.

The new problems can then be resolved by undoing #625.

I've tested across various platforms and as far as I can tell the button now has a consistent height and background.