### PR TITLE
Update v3 directive example to have quoted string

### DIFF
--- a/src/guide/migration/custom-directives.md
+++ b/src/guide/migration/custom-directives.md
@@ -27,7 +27,7 @@ In Vue 2, custom directives were created by using the hooks listed below to targ
 Here’s an example of this:
 
 ```html
-<p v-highlight="yellow">Highlight this text bright yellow</p>
+<p v-highlight="'yellow'">Highlight this text bright yellow</p>
 ```
 
 ```js
@@ -68,7 +68,7 @@ const MyDirective = {
 The resulting API could be used like this, mirroring the example from earlier:
 
 ```html
-<p v-highlight="yellow">Highlight this text bright yellow</p>
+<p v-highlight="'yellow'">Highlight this text bright yellow</p>
 ```
 
 ```js


### PR DESCRIPTION


## Description of Problem
Users are copying example from directives docs and getting into a problem where the directive doesn't seem to be working.

## Proposed Solution
Use a string in the example

## Additional Information
I've seen this cause confusion several times. The examples don't show a variable `yellow` defined, and because a string is expected the example, as is, will fail. I believe adding the extra `'` quotes will make it clearer, and for anyone copy-pasting won't cause issues. Alternatively, the variable could be shown, but that would make examples longer.