### PR TITLE
Reduce heading levels for Template Refs to match other pages

### DIFF
--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -1,4 +1,4 @@
-## Template Refs
+# Template Refs
 
 > This section uses [single-file component](single-file-component.html) syntax for code examples
 
@@ -35,7 +35,7 @@ Here we are exposing `root` on the render context and binding it to the div as i
 
 Refs used as templates refs behave just like any other refs: they are reactive and can be passed into (or returned from) composition functions.
 
-### Usage with JSX
+## Usage with JSX
 
 ```js
 export default {
@@ -53,7 +53,7 @@ export default {
 }
 ```
 
-### Usage inside `v-for`
+## Usage inside `v-for`
 
 Composition API template refs do not have special handling when used inside `v-for`. Instead, use function refs to perform custom handling:
 


### PR DESCRIPTION
## Description of Problem

The headings in `composition-api-template-refs.md` are `<h2>` and `<h3>`, rather than the `<h1>` and `<h2>` used by every other page.

## Proposed Solution

Remove the extra `#` signs from the headings.