### PR TITLE
Clarify the usage of toRefs and toRef for optional props

### DIFF
--- a/src/api/refs-api.md
+++ b/src/api/refs-api.md
@@ -84,6 +84,8 @@ export default {
 }
 ```
 
+`toRef` will return a usable ref even if the source property doesn't currently exist. This makes it especially useful when working with optional props, which wouldn't be picked up by [`toRefs`](#torefs).
+
 ## `toRefs`
 
 Converts a reactive object to a plain object where each property of the resulting object is a [`ref`](#ref) pointing to the corresponding property of the original object.
@@ -139,6 +141,8 @@ export default {
   }
 }
 ```
+
+`toRefs` will only generate refs for properties that are included in the source object. To create a ref for a specific property use [`toRef`](#toref) instead.
 
 ## `isRef`
 

--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -18,7 +18,10 @@ Let’s imagine that in our app, we have a view to show a list of repositories o
 export default {
   components: { RepositoriesFilters, RepositoriesSortBy, RepositoriesList },
   props: {
-    user: { type: String }
+    user: {
+      type: String,
+      required: true
+    }
   },
   data () {
     return {
@@ -86,7 +89,10 @@ Let’s add `setup` to our component:
 export default {
   components: { RepositoriesFilters, RepositoriesSortBy, RepositoriesList },
   props: {
-    user: { type: String }
+    user: {
+      type: String,
+      required: true
+    }
   },
   setup(props) {
     console.log(props) // { user: '' }
@@ -192,7 +198,10 @@ import { ref } from 'vue'
 export default {
   components: { RepositoriesFilters, RepositoriesSortBy, RepositoriesList },
   props: {
-    user: { type: String }
+    user: {
+      type: String,
+      required: true
+    }
   },
   setup (props) {
     const repositories = ref([])
@@ -449,7 +458,10 @@ import { toRefs } from 'vue'
 export default {
   components: { RepositoriesFilters, RepositoriesSortBy, RepositoriesList },
   props: {
-    user: { type: String }
+    user: {
+      type: String,
+      required: true
+    }
   },
   setup (props) {
     const { user } = toRefs(props)
@@ -495,7 +507,10 @@ import useRepositoryFilters from '@/composables/useRepositoryFilters'
 export default {
   components: { RepositoriesFilters, RepositoriesSortBy, RepositoriesList },
   props: {
-    user: { type: String }
+    user: {
+      type: String,
+      required: true
+    }
   },
   setup(props) {
     const { user } = toRefs(props)

--- a/src/guide/composition-api-setup.md
+++ b/src/guide/composition-api-setup.md
@@ -34,7 +34,7 @@ export default {
 However, because `props` are reactive, you **cannot use ES6 destructuring** because it will remove props reactivity.
 :::
 
-If you need to destructure your props, you can do this safely by utilizing the [toRefs](reactivity-fundamentals.html#destructuring-reactive-state) inside of the `setup` function.
+If you need to destructure your props, you can do this by utilizing the [toRefs](reactivity-fundamentals.html#destructuring-reactive-state) inside of the `setup` function:
 
 ```js
 // MyBook.vue
@@ -43,6 +43,20 @@ import { toRefs } from 'vue'
 
 setup(props) {
 	const { title } = toRefs(props)
+
+	console.log(title.value)
+}
+```
+
+If `title` is an optional prop, it could be missing from `props`. In that case, `toRefs` won't create a ref for `title`. Instead you'd need to use `toRef`:
+
+```js
+// MyBook.vue
+
+import { toRef } from 'vue'
+
+setup(props) {
+	const title = toRef(props, 'title')
 
 	console.log(title.value)
 }


### PR DESCRIPTION
## Description of Problem

This was originally reported in #562.

There is a problem with using `toRefs` to destructure props when a prop is optional:

```js
setup (props) {
  // This assumes `props` has a title property
  const { title } = toRefs(props)
}
```

The documentation seems to encourage this pattern but in practice it fails if the prop is missing as no ref will be created. This not only requires extra work to handle an `undefined` ref but it also causes problems if the prop is subsequently added (e.g. via `v-bind="obj"`).

## Proposed Solution

There are various ways this could be addressed through changes to the library but I've assumed that the current behaviour is correct and should be reflected in the documentation.

In `composition-api-introduction.md` I've just marked all the props as `required`. I didn't want to address the problem directly on this page so I just made this tweak to justify the use of `toRefs`.

`composition-api-setup.md` is where I've addressed the problem head-on. The current documentation describes using `toRefs` as 'safe', which it definitely isn't. I've added a brief explanation and an example of using `toRef` instead.

I've also made footnotes in the API entries for `toRefs` and `toRef` to mention this problem.

## Additional Information

This is a best practices recommendation for working around a shortcoming of the library. With that in mind, I think it would be best to gather a few opinions on whether this is actually the way we want to go.