### PR TITLE
feat: migration badges support i18n

### DIFF
--- a/src/.vuepress/components/MigrationBadges.vue
+++ b/src/.vuepress/components/MigrationBadges.vue
@@ -12,7 +12,7 @@ export default {
       type: Array,
       default: () => [],
       validator(value) {
-        return value.every((badge) => Object.keys(validBadges).includes(badge))
+        return value.every(badge => Object.keys(validBadges).includes(badge))
       }
     }
   },

--- a/src/.vuepress/components/MigrationBadges.vue
+++ b/src/.vuepress/components/MigrationBadges.vue
@@ -1,5 +1,10 @@
 <script>
-const validBadges = ['new', 'breaking', 'removed', 'updated']
+const validBadges = {
+  new: 'new',
+  breaking: 'breaking',
+  removed: 'removed',
+  updated: 'updated'
+}
 
 export default {
   props: {
@@ -7,8 +12,13 @@ export default {
       type: Array,
       default: () => [],
       validator(value) {
-        return value.every(badge => validBadges.includes(badge))
+        return value.every((badge) => Object.keys(validBadges).includes(badge))
       }
+    }
+  },
+  data() {
+    return {
+      validBadges
     }
   }
 }
@@ -21,7 +31,7 @@ export default {
       :class="`migration-badge is-${badgeType}`"
       :key="`badge-type-${badgeType}`"
     >
-      {{ badgeType }}
+      {{ validBadges[badgeType] }}
     </span>
   </div>
 </template>


### PR DESCRIPTION
## Description of Problem
- Sometimes we need in18 to display the badge vocabulary.

## Proposed Solution
- add dictionary.

## Additional Information

[vuejs/docs-next-zh-cn PR](https://github.com/vuejs/docs-next-zh-cn/pull/220/files) : 
![image](https://user-images.githubusercontent.com/8652596/97100259-a73f1200-16cc-11eb-9904-ad4654782dc0.png)

![image](https://user-images.githubusercontent.com/8652596/97100268-c76ed100-16cc-11eb-9314-cfae735329af.png)



