### PR TITLE
typo at Typing `refs`

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -194,7 +194,7 @@ const Component = defineComponent({
 })
 ```
 
-### Typing `ref`s
+### Typing `refs`
 
 Refs infer the type from the initial value:
 


### PR DESCRIPTION
fix typo at Typing `refs`

## Description of Problem
When I read the document, I found it strange here.

## Proposed Solution
fix typo.

## Additional Information
none.