### PR TITLE
Fix broken text css-vs-js-ease.svg

### DIFF
--- a/src/.vuepress/public/images/css-vs-js-ease.svg
+++ b/src/.vuepress/public/images/css-vs-js-ease.svg
@@ -866,7 +866,7 @@
   <rect class="cls-1" x="437.4" y="205.3" width="10.2" height="10.23"/>
   <rect class="cls-1" x="447.6" y="205.3" width="10.2" height="10.23"/>
   <rect class="cls-1" x="457.8" y="205.3" width="10.2" height="10.23"/>
-  <text class="cls-2" transform="translate(61.5 261.7)"><tspan class="cls-3">C</tspan><tspan class="cls-4" x="8.5" y="0">S</tspan><tspan x="14.5" y="0">S - limi</tspan><tspan class="cls-4" x="51.1" y="0">t</tspan><tspan class="cls-5" x="54.8" y="0">ed handles</tspan></text>
+  <text class="cls-2" transform="translate(61.5 261.7)"><tspan class="cls-3">C</tspan><tspan class="cls-4" x="8.5" y="0">S</tspan><tspan x="14.5" y="0">S - limi</tspan><tspan class="cls-4" x="57" y="0">t</tspan><tspan class="cls-5" x="61" y="0">ed handles</tspan></text>
   <text class="cls-2" transform="translate(312.7 261.7)">JS - multiple handles</text>
   <text class="cls-6" transform="translate(97.3 228.2)">P<tspan class="cls-7" x="5.7" y="0">r</tspan><tspan x="9" y="0">og</tspan><tspan class="cls-8" x="19.5" y="0">r</tspan><tspan class="cls-9" x="22.9" y="0">ess</tspan></text>
   <text class="cls-6" transform="translate(345.3 228.2)">P<tspan class="cls-7" x="5.7" y="0">r</tspan><tspan x="9" y="0">og</tspan><tspan class="cls-8" x="19.5" y="0">r</tspan><tspan class="cls-9" x="22.9" y="0">ess</tspan></text>


### PR DESCRIPTION
## Description of Problem
#564 The text crawls over the text
#612 was good but I think that the text looks inverted like `limtied`, yet.

**#612 solution**
<img width="429" alt="スクリーンショット 2020-11-02 15 02 51" src="https://user-images.githubusercontent.com/26079835/97835182-f0224680-1d1c-11eb-81cb-f705b6f463f6.png">

## Proposed Solution

**this PR**
<img width="429" alt="スクリーンショット 2020-11-02 15 02 40" src="https://user-images.githubusercontent.com/26079835/97835214-03cdad00-1d1d-11eb-8688-36704be9c044.png">
