### PR TITLE
docs: fix typo in migration/introduction.md

### DIFF
--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -112,7 +112,7 @@ The following consists a list of breaking changes from 2.x:
 - [$on, $off and $once instance methods](/guide/migration/events-api.html)
 - [Filters](/guide/migration/filters.html)
 - [Inline templates attributes](/guide/migration/inline-template-attribute.html)
-- [`$children` intance property](/guide/migration/children.md)
+- [`$children` instance property](/guide/migration/children.md)
 - `$destroy` instance method. Users should no longer manually manage the lifecycle of individual Vue components.
 
 ## Supporting Libraries


### PR DESCRIPTION
fix typo