### PR TITLE
Fix a typo

### DIFF
--- a/src/guide/contributing/translations.md
+++ b/src/guide/contributing/translations.md
@@ -1,6 +1,6 @@
 # Translations
 
-Vue has spread across the globe, with the core team being in at least half a dozen different timezones. [The forum](https://forum.vuejs.org/) includes 7 languages and counting and many of our docs have [actively-maintained translations](https://github.com/vuejs?utf8=%E2%9C%93&q=vuejs.org). We'are very proud of Vue's international reach, but we can do even better.
+Vue has spread across the globe, with the core team being in at least half a dozen different timezones. [The forum](https://forum.vuejs.org/) includes 7 languages and counting and many of our docs have [actively-maintained translations](https://github.com/vuejs?utf8=%E2%9C%93&q=vuejs.org). We're very proud of Vue's international reach, but we can do even better.
 
 ## Can we start translating Vue 3 docs?
 


### PR DESCRIPTION
## Description of Problem

There is a typo on the "Translations" page.

## Proposed Solution

It is now corrected.

## Additional Information
