### PR TITLE
Increase header depth and tweak wording in transitions-overview.md

### DIFF
--- a/src/guide/transitions-overview.md
+++ b/src/guide/transitions-overview.md
@@ -72,9 +72,9 @@ Vue.createApp(Demo).mount('#demo')
 
 <common-codepen-snippet title="Create animation with a class" slug="ff45b91caf7a98c8c9077ad8ab539260" tab="css,result" :editable="false" :preview="false" />
 
-# Transitions with Style Bindings
+## Transitions with Style Bindings
 
-Some transition affects can be applied by interpolating values, for instance by binding a style to an element while an interaction occurs. Take this example for instance:
+Some transition effects can be applied by interpolating values, for instance by binding a style to an element while an interaction occurs. Take this example for instance:
 
 ```html
 <div id="demo">
@@ -152,7 +152,7 @@ You may also find that entrances look better with slightly more time than an exi
 
 ## Easing
 
-Easing is an important way to convey depth in an animation. One of the most common mistakes newcomers to animation have is to use `ease-in` for entrances, and `ease-out` for exits. You'll actually need the opposite.
+Easing is an important way to convey depth in an animation. One of the most common mistakes newcomers to animation make is to use `ease-in` for entrances, and `ease-out` for exits. You'll actually need the opposite.
 
 If we were to apply these states to a transition, it would look something like this:
 


### PR DESCRIPTION
3 small changes to `transitions-overview.md`:

1. Change `<h1>` to `<h2>` for a sub-header.
2. Change *affects* to *effects* as that seems to be what was intended.
3. Change *have* to *make* as I think the sentence reads better that way.