### PR TITLE
Fix two examples of using h with components and slots

### DIFF
--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -370,11 +370,15 @@ To pass slots to a child component using render functions:
 render() {
   // `<div><child v-slot="props"><span>{{ props.text }}</span></child></div>`
   return Vue.h('div', [
-    Vue.h('child', {}, {
+    Vue.h(
+      Vue.resolveComponent('child'),
+      {},
       // pass `slots` as the children object
       // in the form of { name: props => VNode | Array<VNode> }
-      default: (props) => Vue.h('span', props.text)
-    })
+      {
+        default: (props) => Vue.h('span', props.text)
+      }
+    )
   ])
 }
 ```
@@ -389,7 +393,9 @@ Vue.h(
   {
     level: 1
   },
-  [Vue.h('span', 'Hello'), ' world!']
+  {
+    default: () => [Vue.h('span', 'Hello'), ' world!']
+  }
 )
 ```
 


### PR DESCRIPTION
## Description of Problem

Two of the examples in `render-function.md` have problems, both related to using `h` with components and slots.

The first example tries to create a component using `Vue.h('child'`. This won't work because it needs to use `resolveComponent`.

The second example triggers a warning:

> [Vue warn]: Non-function value encountered for default slot. Prefer function slots for better performance.

You can see it yourself here: https://jsfiddle.net/skirtle/ho9t3upv/

When using `h` to create an HTML element there are various different ways to pass the children. However, when creating a component the children have to be passed as a slot object containing functions, otherwise the warning above is shown.

## Proposed Solution

In the first example I have also adjusted the spacing to accommodate the `Vue.resolveComponent`.

The second example is intended to illustrate how painful it is to write `render` functions without JSX. As well as fixing the warning, adding the extra complication of the slot object actually helps to reinforce this point.