### PR TITLE
docs: update component-slots.md

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -308,10 +308,11 @@ Note that the abbreviated syntax for default slot **cannot** be mixed with named
 ```html
 <!-- INVALID, will result in warning -->
 <todo-list v-slot="slotProps">
-  <todo-list v-slot:default="slotProps">
+  <template v-slot:default="slotProps">
     <i class="fas fa-check"></i>
     <span class="green">{{ slotProps.item }}</span>
-  </todo-list>
+  </template>
+  
   <template v-slot:other="otherSlotProps">
     slotProps is NOT available here
   </template>

--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -308,10 +308,8 @@ Note that the abbreviated syntax for default slot **cannot** be mixed with named
 ```html
 <!-- INVALID, will result in warning -->
 <todo-list v-slot="slotProps">
-  <template v-slot:default="slotProps">
-    <i class="fas fa-check"></i>
-    <span class="green">{{ slotProps.item }}</span>
-  </template>
+  <i class="fas fa-check"></i>
+  <span class="green">{{ slotProps.item }}</span>
   
   <template v-slot:other="otherSlotProps">
     slotProps is NOT available here


### PR DESCRIPTION
## Description of Problem

When the todo-list is nested in the other todo-list in the yellow box example, there is ambiguity compared with the red box example.

If my understanding is wrong, correct it please. thank you.

![image](https://user-images.githubusercontent.com/27997635/98614378-456ce200-2333-11eb-949b-c8fd87256367.png)

## Proposed Solution

Replace the todo-list in the yellow box with template like this

![image](https://user-images.githubusercontent.com/27997635/98614624-c5934780-2333-11eb-9c60-b19bdafde17c.png)

## Additional Information
