### PR TITLE
Revise the migration guide for $children, especially the example

### DIFF
--- a/src/guide/migration/children.md
+++ b/src/guide/migration/children.md
@@ -7,32 +7,34 @@ badges:
 
 ## Overview
 
-`$children` instance property removed from Vue 3.0 and no longer supported.
+The `$children` instance property has been removed from Vue 3.0 and is no longer supported.
 
 ## 2.x Syntax
 
 In 2.x, developers could access direct child components of the current instance with `this.$children`:
 
-```html
-<div ref="app" id="app">
-  <img alt="Vue logo" src="./assets/logo.png" width="25%" />
-  <my-button>Change logo</my-button>
-</div>
-```
+```vue
+<template>
+  <div>
+    <img alt="Vue logo" src="./assets/logo.png">
+    <my-button>Change logo</my-button>
+  </div>
+</template>
 
-```js
+<script>
+import MyButton from './MyButton'
+
 export default {
-  name: "App",
   components: {
-    MyButton,
+    MyButton
   },
   mounted() {
-    console.log(this.$children); // [VueComponent]
-  },
-};
+    console.log(this.$children) // [VueComponent]
+  }
+}
 </script>
 ```
 
 ## 3.x Update
 
-In 3.x, `$children` property is removed and no longer supported. Instead, if you need to access a child component instance, we recommend using [$refs](/guide/component-template-refs.html#template-refs).
+In 3.x, the `$children` property is removed and no longer supported. Instead, if you need to access a child component instance, we recommend using [$refs](/guide/component-template-refs.html#template-refs).


### PR DESCRIPTION
I've made some tweaks to the migration guide about the removal of `$children`.

For the example, the HTML seemed to be an in-DOM template, whereas the JS seemed to be from an SFC. I've made it all an SFC. I've also removed several attributes from the template that didn't seem to be adding anything to the example.