### PR TITLE
Add TypeScript + Webpack Configuration Tip

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -26,6 +26,31 @@ Note that you have to include `strict: true` (or at least `noImplicitThis: true`
 
 See [TypeScript compiler options docs](https://www.typescriptlang.org/docs/handbook/compiler-options.html) for more details.
 
+## Webpack Configuration
+
+If you are using a custom Webpack configuration `ts-loader` needs to be configured to parse `<script lang="ts">` blocks in `.vue` files:
+
+```js{10}
+// webpack.config.js
+module.exports = {
+  ...
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        options: {
+          appendTsSuffixTo: [/\.vue$/],
+        },
+        exclude: /node_modules/,
+      },
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+      }
+      ...
+```
+
 ## Development Tooling
 
 ### Project Creation


### PR DESCRIPTION
## Description of Problem
`.vue` imports in `<script lang="ts">` blocks aren't resolved by default by ts-loader. Attempting to do so will result in a `[Vue warn]: Failed to resolve component: my-component` console error.

## Proposed Solution
Document the required configuration (using the `appendTsSuffixTo` ts-loader option).

## Additional Information
Credit:
- https://lmiller1990.github.io/electic/posts/20200406_webpack_for_vue_3.html
- https://github.com/starkovsky/vue3-webpack-boilerplate/blob/master/webpack.config.js#L42