### PR TITLE
Move the migration and contribution guidelines in separate sections

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -116,15 +116,6 @@ const sidebar = {
         '/guide/a11y-standards',
         '/guide/a11y-resources'
       ]
-    },
-    {
-      title: 'Contribute to the Docs',
-      collapsable: true,
-      children: [
-        '/guide/contributing/writing-guide',
-        '/guide/contributing/doc-style-guide',
-        '/guide/contributing/translations'
-      ]
     }
   ],
   api: [
@@ -213,6 +204,17 @@ const sidebar = {
         '/guide/migration/v-if-v-for',
         '/guide/migration/v-bind',
         '/guide/migration/watch'
+      ]
+    }
+  ],
+  contributing: [
+    {
+      title: 'Contribute to the Docs',
+      collapsable: false,
+      children: [
+        '/guide/contributing/writing-guide',
+        '/guide/contributing/doc-style-guide',
+        '/guide/contributing/translations'
       ]
     }
   ]
@@ -403,6 +405,7 @@ module.exports = {
     sidebar: {
       collapsable: false,
       '/guide/migration/': sidebar.migration,
+      '/guide/contributing/': sidebar.contributing,
       '/guide/': sidebar.guide,
       '/community/': sidebar.guide,
       '/cookbook/': sidebar.cookbook,

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -118,42 +118,6 @@ const sidebar = {
       ]
     },
     {
-      title: 'Migration Guide',
-      collapsable: true,
-      children: [
-        '/guide/migration/introduction',
-        '/guide/migration/array-refs',
-        '/guide/migration/async-components',
-        '/guide/migration/attribute-coercion',
-        '/guide/migration/attrs-includes-class-style',
-        '/guide/migration/children',
-        '/guide/migration/custom-directives',
-        '/guide/migration/custom-elements-interop',
-        '/guide/migration/data-option',
-        '/guide/migration/emits-option',
-        '/guide/migration/events-api',
-        '/guide/migration/filters',
-        '/guide/migration/fragments',
-        '/guide/migration/functional-components',
-        '/guide/migration/global-api',
-        '/guide/migration/global-api-treeshaking',
-        '/guide/migration/inline-template-attribute',
-        '/guide/migration/key-attribute',
-        '/guide/migration/keycode-modifiers',
-        '/guide/migration/listeners-removed',
-        '/guide/migration/props-default-this',
-        '/guide/migration/render-function-api',
-        '/guide/migration/slots-unification',
-        '/guide/migration/transition',
-        '/guide/migration/transition-group',
-        '/guide/migration/v-on-native-modifier-removed',
-        '/guide/migration/v-model',
-        '/guide/migration/v-if-v-for',
-        '/guide/migration/v-bind',
-        '/guide/migration/watch'
-      ]
-    },
-    {
       title: 'Contribute to the Docs',
       collapsable: true,
       children: [
@@ -211,6 +175,44 @@ const sidebar = {
         '/examples/elastic-header',
         '/examples/select2',
         '/examples/todomvc'
+      ]
+    }
+  ],
+  migration: [
+    '/guide/migration/introduction',
+    {
+      title: 'Details',
+      collapsable: false,
+      children: [
+        '/guide/migration/array-refs',
+        '/guide/migration/async-components',
+        '/guide/migration/attribute-coercion',
+        '/guide/migration/attrs-includes-class-style',
+        '/guide/migration/children',
+        '/guide/migration/custom-directives',
+        '/guide/migration/custom-elements-interop',
+        '/guide/migration/data-option',
+        '/guide/migration/emits-option',
+        '/guide/migration/events-api',
+        '/guide/migration/filters',
+        '/guide/migration/fragments',
+        '/guide/migration/functional-components',
+        '/guide/migration/global-api',
+        '/guide/migration/global-api-treeshaking',
+        '/guide/migration/inline-template-attribute',
+        '/guide/migration/key-attribute',
+        '/guide/migration/keycode-modifiers',
+        '/guide/migration/listeners-removed',
+        '/guide/migration/props-default-this',
+        '/guide/migration/render-function-api',
+        '/guide/migration/slots-unification',
+        '/guide/migration/transition',
+        '/guide/migration/transition-group',
+        '/guide/migration/v-on-native-modifier-removed',
+        '/guide/migration/v-model',
+        '/guide/migration/v-if-v-for',
+        '/guide/migration/v-bind',
+        '/guide/migration/watch'
       ]
     }
   ]
@@ -291,10 +293,6 @@ module.exports = {
             link: '/guide/introduction'
           },
           {
-            text: 'Migration Guide',
-            link: '/guide/migration/introduction'
-          },
-          {
             text: 'Style Guide',
             link: '/style-guide/'
           },
@@ -305,6 +303,14 @@ module.exports = {
           {
             text: 'Examples',
             link: '/examples/markdown'
+          },
+          {
+            text: 'Contribute',
+            link: '/guide/contributing/writing-guide'
+          },
+          {
+            text: 'Migration from Vue 2',
+            link: '/guide/migration/introduction'
           }
         ]
       },
@@ -396,6 +402,7 @@ module.exports = {
     sidebarDepth: 2,
     sidebar: {
       collapsable: false,
+      '/guide/migration/': sidebar.migration,
       '/guide/': sidebar.guide,
       '/community/': sidebar.guide,
       '/cookbook/': sidebar.cookbook,


### PR DESCRIPTION
## Description of Problem

Currently, the _Migration Guide_ and _Contribute to the Docs_ section are nested in the sidebar under the first docs section (_Guide_). Here're are some minor issues caused by this nesting:

1. **Navigation:** When you click the Migration Guide link from the Docs dropdown menu, the sidebar is not scrolling to the relevant section which could cause confusion. For example, if you're on the top of the [Template refs](https://v3.vuejs.org/guide/component-template-refs.html) section and then click on the _Migration Guide_ from the _Docs_ dropdown, it's not clear there's a list of relevant sub-sections you can navigate to.
1. **Copy**: The Docs dropdown is repeatedly using the _Guide_ keyword in the dropdown options.
1. **Discoverability**: It's hard to locate contribution guidelines.

## Proposed Solution

1. Move the migration and contribution guidelines in separate top-level sections with their own sidebar.
1. Update the _Docs_ dropdown with something like the following (see screenshots).

Please check deployed preview [here](https://deploy-preview-699--vue-docs-next-preview.netlify.app/guide/migration/introduction.html)

