### PR TITLE
updated routing.md

### DIFF
--- a/src/guide/routing.md
+++ b/src/guide/routing.md
@@ -2,7 +2,7 @@
 
 ## Official Router
 
-For most Single Page Applications, it's recommended to use the officially-supported [vue-router library](https://github.com/vuejs/vue-router). For more details, see vue-router's [documentation](https://router.vuejs.org/).
+For most Single Page Applications, it's recommended to use the officially-supported [vue-router library](https://github.com/vuejs/vue-router). For more details, see vue-router's [documentation](https://next.router.vuejs.org/).
 
 ## Simple Routing from Scratch
 


### PR DESCRIPTION
change the documentation link from https://router.vuejs.org/ to https://next.router.vuejs.org/
