### PR TITLE
Updated vm.pick condition for Radio

### DIFF
--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -233,7 +233,7 @@ The `true-value` and `false-value` attributes don't affect the input's `value` a
 
 ```js
 // when checked:
-vm.pick === vm.a
+vm.pick === 'a'
 ```
 
 ### Select Options


### PR DESCRIPTION
when 'radio' is checked, `vm.pick` should be `a`.

## Description of Problem

## Proposed Solution

## Additional Information
