### PR TITLE
docs: Add type definition for `globalProperties` in TypeScript chapter.

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -135,9 +135,9 @@ const Component = defineComponent({
 
 ### Augmenting Types for Use with Plugins or Declarations by User
 
-Vue 3 provides `globalProperties` property for [plugins](./plugins.html#writing-a-plugin) to add to Vue’s global properties in each component instance. In some cases, we also need to [do it by ourselves](../api/application-config.html#globalproperties):
+Vue 3 provides a [`globalProperties` object](../api/application-config.html#globalproperties) that can be used to add a global property that can be accessed in any component instance. For example, a [plugin](./plugins.html#writing-a-plugin) might want to inject a shared global object or function.
 
-```typescript
+```ts
 // User Definition
 import axios from 'axios'
 
@@ -154,11 +154,11 @@ export default {
 }
 ```
 
-In order to let TypeScript know the properties we (or plugins) added and their types, the [Module Augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) feature can help us.
+In order to tell TypeScript about these new properties, we can use [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).
 
-For the above example, we (or plugins) can add the following code of type definition:
+In the above example, we could add the following type declaration:
 
-```typescript
+```ts
 import axios from 'axios'
 
 declare module '@vue/runtime-core' {
@@ -168,9 +168,9 @@ declare module '@vue/runtime-core' {
 }
 ```
 
-We should put the above code wherever it can be loaded, such as `main.ts` where you define these properties, or a `*.d.ts` file in `src/typings` folder automatically loaded by TypeScript. For plugins, it should be placed in the location specified by the `types` property in `package.json`. 
+We can put this type declaration in the same file, or in a project-wide `*.d.ts` file (for example, in the `src/typings` folder that is automatically loaded by TypeScript). For library/plugin authors, this file should be specified in the `types` property in `package.json`.
 
-The `ComponentCustomProperties` type can help us define the custom options, see the code of [definition in `@vue/runtime-core`](https://github.com/vuejs/vue-next/blob/2587f36fe311359e2e34f40e8e47d2eebfab7f42/packages/runtime-core/src/componentOptions.ts#L64-L80) and [unit tests for TypeScript types](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) to learn more.
+For more information about the `ComponentCustomProperties` type, see its [definition in `@vue/runtime-core`](https://github.com/vuejs/vue-next/blob/2587f36fe311359e2e34f40e8e47d2eebfab7f42/packages/runtime-core/src/componentOptions.ts#L64-L80) and [the TypeScript unit tests](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) to learn more.
 
 ### Annotating Return Types
 

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -139,14 +139,18 @@ Vue 3 provides `globalProperties` property for [plugins](./plugins.html#writing-
 
 ```typescript
 // User Definition
-const app = Vue.createApp()
-app.config.globalProperties.foo = 'bar'
+import axios from 'axios'
 
-// Plugin
+const app = Vue.createApp()
+app.config.globalProperties.$http = axios
+
+// Plugin for validate some data
 export default {
-    install(app, options) {
-        app.config.globalProperties.foo = 'bar'
+  install(app, options) {
+    app.config.globalProperties.$validate = (data: object, rule: object) => {
+      // check whether the object meets certain rules
     }
+  }
 }
 ```
 
@@ -155,16 +159,20 @@ In order to let TypeScript know the attributes we (or plugins) added and their t
 For the above example, we (or plugins) can add the following code of type definition:
 
 ```typescript
+import axios from 'axios'
+
 declare module '@vue/runtime-core' {
-    export interface ComponentCustomProperties {
-        foo: string
-    }
+  export interface ComponentCustomProperties {
+    axios: typeof axios
+  }
 }
 ```
 
-Then you can use it in TypeScript by correct type inference.
+We should put the above code wherever it can be loaded, such as `main.js` where you define these properties, or the `*.d.ts` file in `src/typings` folder automatically loaded by TypeScript. For plugins, it locates in the location specified by the `types` property in `package.json`. 
 
-The `ComponentCustomProperties` type can help us define the custom options, see the code of [definition](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentOptions.ts#L63-L79), [use](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentOptions.ts#L97) and [unit test](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) in `@vue/runtime-core` to learn more.
+After TypeScript loaded them, we can use it in TypeScript by correct type inference.
+
+The `ComponentCustomProperties` type can help us define the custom options, see the code of [definition in `@vue/runtime-core`](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentOptions.ts#L63-L111) and [unit tests for Typescript types](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) to learn more.
 
 ### Annotating Return Types
 

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -133,7 +133,7 @@ const Component = defineComponent({
 })
 ```
 
-### Augmenting Types for Use with Plugins or User Definitions
+### Augmenting Types for Use with Plugins or Declarations by User
 
 Vue 3 provides `globalProperties` property for [plugins](./plugins.html#writing-a-plugin) to add to Vue’s global properties in each component instance. In some cases, we also need to [do it by ourselves](../api/application-config.html#globalproperties):
 
@@ -141,10 +141,10 @@ Vue 3 provides `globalProperties` property for [plugins](./plugins.html#writing-
 // User Definition
 import axios from 'axios'
 
-const app = Vue.createApp()
+const app = Vue.createApp({})
 app.config.globalProperties.$http = axios
 
-// Plugin for validate some data
+// Plugin for validating some data
 export default {
   install(app, options) {
     app.config.globalProperties.$validate = (data: object, rule: object) => {
@@ -154,7 +154,7 @@ export default {
 }
 ```
 
-In order to let TypeScript know the attributes we (or plugins) added and their types, the [Module Augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) feature can help us.
+In order to let TypeScript know the properties we (or plugins) added and their types, the [Module Augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) feature can help us.
 
 For the above example, we (or plugins) can add the following code of type definition:
 
@@ -168,11 +168,9 @@ declare module '@vue/runtime-core' {
 }
 ```
 
-We should put the above code wherever it can be loaded, such as `main.js` where you define these properties, or the `*.d.ts` file in `src/typings` folder automatically loaded by TypeScript. For plugins, it locates in the location specified by the `types` property in `package.json`. 
+We should put the above code wherever it can be loaded, such as `main.ts` where you define these properties, or a `*.d.ts` file in `src/typings` folder automatically loaded by TypeScript. For plugins, it should be placed in the location specified by the `types` property in `package.json`. 
 
-After TypeScript loaded them, we can use it in TypeScript by correct type inference.
-
-The `ComponentCustomProperties` type can help us define the custom options, see the code of [definition in `@vue/runtime-core`](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentOptions.ts#L63-L111) and [unit tests for Typescript types](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) to learn more.
+The `ComponentCustomProperties` type can help us define the custom options, see the code of [definition in `@vue/runtime-core`](https://github.com/vuejs/vue-next/blob/2587f36fe311359e2e34f40e8e47d2eebfab7f42/packages/runtime-core/src/componentOptions.ts#L64-L80) and [unit tests for TypeScript types](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) to learn more.
 
 ### Annotating Return Types
 

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -133,6 +133,39 @@ const Component = defineComponent({
 })
 ```
 
+### Augmenting Types for Use with Plugins or User Definitions
+
+Vue 3 provides `globalProperties` property for [plugins](./plugins.html#writing-a-plugin) to add to Vue’s global properties in each component instance. In some cases, we also need to [do it by ourselves](../api/application-config.html#globalproperties):
+
+```typescript
+// User Definition
+const app = Vue.createApp()
+app.config.globalProperties.foo = 'bar'
+
+// Plugin
+export default {
+    install(app, options) {
+        app.config.globalProperties.foo = 'bar'
+    }
+}
+```
+
+In order to let TypeScript know the attributes we (or plugins) added and their types, the [Module Augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation) feature can help us.
+
+For the above example, we (or plugins) can add the following code of type definition:
+
+```typescript
+declare module '@vue/runtime-core' {
+    export interface ComponentCustomProperties {
+        foo: string
+    }
+}
+```
+
+Then you can use it in TypeScript by correct type inference.
+
+The `ComponentCustomProperties` type can help us define the custom options, see the code of [definition](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentOptions.ts#L63-L79), [use](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/componentOptions.ts#L97) and [unit test](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) in `@vue/runtime-core` to learn more.
+
 ### Annotating Return Types
 
 Because of the circular nature of Vue’s declaration files, TypeScript may have difficulties inferring the types of computed. For this reason, you may need to annotate the return type of computed properties.
@@ -150,7 +183,7 @@ const Component = defineComponent({
     // needs an annotation
     greeting(): string {
       return this.message + '!'
-    }
+    },
 
     // in a computed with a setter, getter needs to be annotated
     greetingUppercased: {

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -133,7 +133,7 @@ const Component = defineComponent({
 })
 ```
 
-### Augmenting Types for Use with Plugins or Declarations by User
+### Augmenting Types for `globalProperties`
 
 Vue 3 provides a [`globalProperties` object](../api/application-config.html#globalproperties) that can be used to add a global property that can be accessed in any component instance. For example, a [plugin](./plugins.html#writing-a-plugin) might want to inject a shared global object or function.
 
@@ -163,12 +163,19 @@ import axios from 'axios'
 
 declare module '@vue/runtime-core' {
   export interface ComponentCustomProperties {
-    axios: typeof axios
+    $http: typeof axios
+    $validate: (data: object, rule: object) => boolean
   }
 }
 ```
 
 We can put this type declaration in the same file, or in a project-wide `*.d.ts` file (for example, in the `src/typings` folder that is automatically loaded by TypeScript). For library/plugin authors, this file should be specified in the `types` property in `package.json`.
+
+::: warning Make sure the declaration file is a TypeScript module
+According to the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/modules.html), any file containing a top-level `import` or `export` is considered a module. Otherwise, it is a script. Only in module, the declarations in an augmentation will be merged, if in script, they will replace the original types, it will make all the default properties missing.
+
+Please make sure there is at least one top-level `import` or `export` in your file -- Especially when you customize the type instead of extending a third-party type in a separate file, at this time, you can add `export {}` to meet the requirements.
+:::
 
 For more information about the `ComponentCustomProperties` type, see its [definition in `@vue/runtime-core`](https://github.com/vuejs/vue-next/blob/2587f36fe311359e2e34f40e8e47d2eebfab7f42/packages/runtime-core/src/componentOptions.ts#L64-L80) and [the TypeScript unit tests](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) to learn more.
 
@@ -198,8 +205,8 @@ const Component = defineComponent({
       },
       set(newValue: string) {
         this.message = newValue.toUpperCase();
-      },
-    },
+      }
+    }
   }
 })
 ```

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -172,9 +172,9 @@ declare module '@vue/runtime-core' {
 We can put this type declaration in the same file, or in a project-wide `*.d.ts` file (for example, in the `src/typings` folder that is automatically loaded by TypeScript). For library/plugin authors, this file should be specified in the `types` property in `package.json`.
 
 ::: warning Make sure the declaration file is a TypeScript module
-According to the [TypeScript documentation](https://www.typescriptlang.org/docs/handbook/modules.html), any file containing a top-level `import` or `export` is considered a module. Otherwise, it is a script. Only in module, the declarations in an augmentation will be merged, if in script, they will replace the original types, it will make all the default properties missing.
+In order to take advantage of module augmentation, you will need to ensure there is at least one top-level `import` or `export` in your file, even if it is just `export {}`.
 
-Please make sure there is at least one top-level `import` or `export` in your file -- Especially when you customize the type instead of extending a third-party type in a separate file, at this time, you can add `export {}` to meet the requirements.
+[In TypeScript](https://www.typescriptlang.org/docs/handbook/modules.html), any file containing a top-level `import` or `export` is considered a 'module'. If type declaration is made outside of a module, it will overwrite the original types rather than augmenting them.
 :::
 
 For more information about the `ComponentCustomProperties` type, see its [definition in `@vue/runtime-core`](https://github.com/vuejs/vue-next/blob/2587f36fe311359e2e34f40e8e47d2eebfab7f42/packages/runtime-core/src/componentOptions.ts#L64-L80) and [the TypeScript unit tests](https://github.com/vuejs/vue-next/blob/master/test-dts/componentTypeExtensions.test-d.tsx) to learn more.


### PR DESCRIPTION
## Description of Problem

See https://github.com/vuejs/vue-next/issues/2220 and https://github.com/vuejs/vue-next/issues/2701 .

The lack of documentation have made many people wonder how to solve TypeScript errors caused by custom types in `globalProperties`, so I tried to fix it.

## Proposed Solution

I added a chapter to the document to explain the origin of this problem and how to solve it.

## Additional Information

In addition, I also found a small sample code syntax error in this document and corrected it.

> In an object, the lack of a comma between the methods will cause a syntax error.