### PR TITLE
docs(ts-support): annotating props with validators and default values

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -172,10 +172,10 @@ Vue does a runtime validation on props with a `type` defined. To provide these t
 ```ts
 import { defineComponent, PropType } from 'vue'
 
-interface ComplexMessage {
+interface Book {
   title: string
-  okMessage: string
-  cancelMessage: string
+  author: string
+  year: number
 }
 
 const Component = defineComponent({
@@ -185,12 +185,9 @@ const Component = defineComponent({
     callback: {
       type: Function as PropType<() => void>
     },
-    message: {
-      type: Object as PropType<ComplexMessage>,
+    book: {
+      type: Object as PropType<Book>,
       required: true
-    },
-    numbers: {
-      type: Array as PropType<number[]>
     }
   }
 })
@@ -204,23 +201,31 @@ to type inference of function expressions, you have to be careful with `validato
 ```ts
 import { defineComponent, PropType } from 'vue'
 
+interface Book {
+  title: string
+  year?: number
+}
+
 const Component = defineComponent({
   props: {
-    numbersA: {
-      type: Array as PropType<number[]>,
+    bookA: {
+      type: Object as PropType<Book>,
       // Make sure to use arrow functions
-      default: () => [],
-      validator: (numbers: number[]) =>
-        numbers.every(x => typeof x === 'number')
+      default: () => ({
+        title: "Arrow Function Expression"
+      }),
+      validator: (book: Book) => !!book.title
     },
-    numbersB: {
-      type: Array as PropType<number[]>,
+    bookB: {
+      type: Object as PropType<Book>,
       // Or provide an explicit this parameter
       default(this: void) {
-        return []
+        return {
+          title: "Function Expression"
+        }
       },
-      validator(this: void, numbers: number[]) {
-        return numbers.every(x => typeof x === 'number')
+      validator(this: void, book: Book) {
+        return !!book.title
       }
     }
   }

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -177,6 +177,7 @@ interface ComplexMessage {
   okMessage: string
   cancelMessage: string
 }
+
 const Component = defineComponent({
   props: {
     name: String,
@@ -185,17 +186,43 @@ const Component = defineComponent({
       type: Function as PropType<() => void>
     },
     message: {
-      type: Object as PropType<ComplexMessage>,
-      required: true,
-      validator(message: ComplexMessage) {
-        return !!message.title
-      }
+      type: Object as PropType<ComplexMessage>
+      required: true
     }
   }
 })
 ```
 
-If you find validator not getting type inference or member completion isn’t working, annotating the argument with the expected type may help address these problems.
+::: warning
+Because of a [design limitation](https://github.com/microsoft/TypeScript/issues/38845) in TypeScript when it comes
+to type inference of function expressions, you have to be careful with `validators` and `default` values for objects and arrays:
+:::
+
+```ts
+import { defineComponent, PropType } from 'vue'
+
+const Component = defineComponent({
+  props: {
+    numbersA: {
+      type: Array as PropType<number[]>,
+      // Make sure to use arrow functions
+      default: () => [],
+      validator: (numbers: number[]) =>
+        numbers.every(x => typeof x === 'number')
+    },
+    numbersB: {
+      type: Array as PropType<number[]>,
+      // Or provide an explicit this parameter
+      default(this: void) {
+        return []
+      },
+      validator(this: void, numbers: number[]) {
+        return numbers.every(x => typeof x === 'number')
+      }
+    }
+  }
+})
+```
 
 ## Using with Composition API
 

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -188,6 +188,9 @@ const Component = defineComponent({
     message: {
       type: Object as PropType<ComplexMessage>
       required: true
+    },
+    numbers: {
+      type: Array as PropType<number[]>
     }
   }
 })

--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -186,7 +186,7 @@ const Component = defineComponent({
       type: Function as PropType<() => void>
     },
     message: {
-      type: Object as PropType<ComplexMessage>
+      type: Object as PropType<ComplexMessage>,
       required: true
     },
     numbers: {


### PR DESCRIPTION
## Description of Problem
The example under [Annotating Props](https://v3.vuejs.org/guide/typescript-support.html#annotating-props) in the TypeScript Support section of the docs would break the prop type for the component because of the `validator` function.
## Proposed Solution
Give an example of how to correctly use `validators` and `default` values for objects and arrays.
## Additional Information
[Related issue](https://github.com/vuejs/vue-next/issues/2474)
