### PR TITLE
doc(api/basic-reactivity): fix syntax highlighting

### DIFF
--- a/src/api/basic-reactivity.md
+++ b/src/api/basic-reactivity.md
@@ -61,7 +61,7 @@ export default {
 
 It also returns `true` if the proxy is created by [`readonly`](#readonly), but is wrapping another proxy created by [`reactive`](#reactive).
 
-```js{7-15}
+```js
 import { reactive, isReactive, readonly } from 'vue'
 export default {
   setup() {


### PR DESCRIPTION
## Description of Problem
Improper use of syntax highlighting for fenced code blocks

## Proposed Solution
Remove meta after the specified language keyword (before the fenced code blocks)
## Additional Information
