### PR TITLE
docs(guide/migration/watch.md): fix typo

### DIFF
--- a/src/guide/migration/watch.md
+++ b/src/guide/migration/watch.md
@@ -8,7 +8,7 @@ badges:
 
 ## Overview
 
-- **BREAKING**: When watching an array, the callback will only trigger when the array is replaced. If you need to to trigger on mutation, the `deep` option must be specified.
+- **BREAKING**: When watching an array, the callback will only trigger when the array is replaced. If you need to trigger on mutation, the `deep` option must be specified.
 
 ## 3.x Syntax
 


### PR DESCRIPTION
## Description of Problem
Fix typo (remove the additional 'to')
