### PR TITLE
Add a link from $attrs to inheritAttrs

### DIFF
--- a/src/api/instance-properties.md
+++ b/src/api/instance-properties.md
@@ -146,3 +146,4 @@ Contains parent-scope attribute bindings and events that are not recognized (and
 
 - **See also:**
   - [Non-Prop Attributes](../guide/component-attrs.html)
+  - [Options / Misc - inheritAttrs](./options-misc.html#inheritattrs)


### PR DESCRIPTION
## Description of Problem

The API entry for `$attrs` doesn't mention `inheritAttrs`.

I recall an occasion when I couldn't remember the name of `inheritAttrs` and I was surprised that it wasn't referenced directly from `$attrs`.

## Proposed Solution

Adding a link in the **See also** section seemed sufficient.

The format for the link text is copied from other links on this same page.