### PR TITLE
fix: error option in async component migration page

### DIFF
--- a/src/guide/migration/async-components.md
+++ b/src/guide/migration/async-components.md
@@ -66,8 +66,8 @@ const asyncPageWithOptions = defineAsyncComponent({
   loader: () => import('./NextPage.vue'),
   delay: 200,
   timeout: 3000,
-  error: ErrorComponent,
-  loading: LoadingComponent
+  errorComponent: ErrorComponent,
+  loadingComponent: LoadingComponent
 })
 ```
 


### PR DESCRIPTION
## Description of Problem
Wrong option field in async component migration page: https://v3.vuejs.org/guide/migration/async-components.html#_3-x-syntax.

## Proposed Solution
change the wrong option name to correct ones.

## Additional Information
![image](https://user-images.githubusercontent.com/7310471/102843798-fa231480-4444-11eb-8de0-470724e75d8e.png)
