### PR TITLE
Added slot to todo list component

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -240,7 +240,7 @@ app.component('todo-list', {
   template: `
     <ul>
       <li v-for="(item, index) in items">
-        {{ item }}
+        <slot>{{ item }}</slot>
       </li>
     </ul>
   `

--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -240,14 +240,14 @@ app.component('todo-list', {
   template: `
     <ul>
       <li v-for="(item, index) in items">
-        <slot>{{ item }}</slot>
+        {{ item }}
       </li>
     </ul>
   `
 })
 ```
 
-We might want to replace the slot to customize it on parent component:
+We might want to replace the `{{ item }}` with a `<slot>` to customize it on parent component:
 
 ```html
 <todo-list>


### PR DESCRIPTION
Added slot to todo list component to emphasize the fact that you can replace the content with custom content.
As the sentence states, this won't work without scoped slots.

## Description of Problem
The code does not make sense for the sentence that follows it:
> We might want to replace the slot to customize it on parent component

## Proposed Solution
Added `<slot>` wrapper to emphasize that there is a slot to customize

## Additional Information
I had to read this example a few times to understand which slot is being customized in order to understand.