### PR TITLE
Add `binding` attribute on application-api directive binding example

### DIFF
--- a/src/api/application-api.md
+++ b/src/api/application-api.md
@@ -132,7 +132,8 @@ An object containing the following properties.
 
 ```js
 app.directive('focus', {
-  mounted(el) {
+  mounted(el, binding) {
+    console.log(binding);
     el.focus()
   }
 })


### PR DESCRIPTION
Update `application-api.md` directive binding argument exemple which contain only `el` exemple and no reference at `binding` attribute.

## Description of Problem

The example is under `binding` attribute explaination but it doesn't contain how to use `binding` attribute. This could been confusing.

## Proposed Solution

Add binding attribute on the example