### PR TITLE
Correct small bugs in the v-for array refs examples

### DIFF
--- a/src/guide/migration/array-refs.md
+++ b/src/guide/migration/array-refs.md
@@ -25,7 +25,9 @@ export default {
   },
   methods: {
     setItemRef(el) {
-      this.itemRefs.push(el)
+      if (el) {
+        this.itemRefs.push(el)
+      }
     }
   },
   beforeUpdate() {
@@ -40,13 +42,15 @@ export default {
 With Composition API:
 
 ```js
-import { ref, onBeforeUpdate, onUpdated } from 'vue'
+import { onBeforeUpdate, onUpdated } from 'vue'
 
 export default {
   setup() {
     let itemRefs = []
     const setItemRef = el => {
-      itemRefs.push(el)
+      if (el) {
+        itemRefs.push(el)
+      }
     }
     onBeforeUpdate(() => {
       itemRefs = []
@@ -55,7 +59,6 @@ export default {
       console.log(itemRefs)
     })
     return {
-      itemRefs,
       setItemRef
     }
   }


### PR DESCRIPTION
I've fixed 3 problems with these examples.

1. `ref` is unused, close #766.
2. The `setItemRef` function needs an `if` check, otherwise removed nodes will be pushed as `null`. This is effectively the same problem I reported in #353, though in a different part of the docs.
3. The `setup` function should not return `itemRefs`, it's highly misleading. `itemRefs` is reassigned in `onBeforeUpdate` but that won't update the value returned from `setup`. There are other ways to fix this (set the `length` to 0 or wrap it in a `ref`) but this seemed the simplest.