### PR TITLE
Migration guide: Mention accessing createApp from a CDN build

### DIFF
--- a/src/guide/migration/global-api.md
+++ b/src/guide/migration/global-api.md
@@ -65,6 +65,14 @@ import { createApp } from 'vue'
 const app = createApp({})
 ```
 
+If you're using a [CDN](/guide/installation.html#cdn) build of Vue then `createApp` is exposed via the global `Vue` object:
+
+```js
+const { createApp } = Vue
+
+const app = createApp({})
+```
+
 An app instance exposes a subset of the current global APIs. The rule of thumb is _any APIs that globally mutate Vue's behavior are now moved to the app instance_. Here is a table of the current global APIs and their corresponding instance APIs:
 
 | 2.x Global API             | 3.x Instance API (`app`)                                                                        |
@@ -198,7 +206,7 @@ export default {
 }
 ```
 
-Using `provide` is especially useful when writing a plugin, as an alternative to `globalProperties`. 
+Using `provide` is especially useful when writing a plugin, as an alternative to `globalProperties`.
 
 ## Share Configurations Among Apps
 


### PR DESCRIPTION
## Description of Problem

I've gone into depth about the problem in #773 but this PR is largely independent of the changes I've proposed there.

In summary, I saw a discussion on Discord where several users were getting confused about migrating a Vue 2 app to Vue 3. The confusion came from the difference between using ESM modules and a CDN build. They had read the migration guide for global API changes but hadn't fully appreciated the differences between ESM and CDN.

To make matters worse, the examples on that page keep flip-flopping between the two styles.

This may not seem like a migration problem but the API change is a significant contributor to the confusion. In Vue 2, everything was done via an object/function called `Vue`. In Vue 3, that object only exists for CDN builds. A familiar-looking object has completely changed roles and unless you grasp the difference between the builds it's really difficult to understand what's going on.

## Proposed Solution

I've included an extra example near the top of the page that explicitly notes how a CDN build differs from the ESM example. It isn't much but I think it'd make a big difference to anyone who is only familiar with one way or the other.

Rewriting the examples on this page to all use the same style would probably be a good idea but I think that should be addressed as part of #773.

There's also an unrelated trailing-space change in the same file, correcting one of my previous changes.