### PR TITLE
feat: add note on isCustomElement in runtime-only builds

### DIFF
--- a/src/api/application-config.md
+++ b/src/api/application-config.md
@@ -94,6 +94,10 @@ Specifies a method to recognize custom elements defined outside of Vue (e.g., us
 
 > Note that all native HTML and SVG tags don't need to be matched in this function - Vue parser performs this check automatically
 
+::: tip Important
+This config option is only respected when using the runtime compiler. If you are using the runtime-only build, `isCustomElement` must be passed to `@vue/compiler-dom` in the build setup instead - for example, via the [`compilerOptions` option in vue-loader](https://vue-loader.vuejs.org/options.html#compileroptions).
+:::
+
 ## optionMergeStrategies
 
 - **Type:** `{ [key: string]: Function }`


### PR DESCRIPTION
## Description of Problem
The `isCustomElement` config option only applies when using the runtime compiler. Since most users will be using the runtime-only compiler (eg. via `vue-loader` or `@vue/cli`), they may attempt to configure this option by mistake (eg. [`vuejs/vue-next` #2779](https://github.com/vuejs/vue-next/issues/2779)).

## Proposed Solution
Let's add a note that they may need to configure `vue-loader`'s `compilerOptions` for custom elements to work properly.

## Additional Information
The language used is [taken from the migration guide](https://github.com/vuejs/docs-next/blob/master/src/guide/migration/global-api.md#L102).