### PR TITLE
Remove slashes before dollar signs

### DIFF
--- a/src/api/instance-methods.md
+++ b/src/api/instance-methods.md
@@ -1,6 +1,6 @@
 # Instance Methods
 
-## \$watch
+## $watch
 
 - **Arguments:**
 
@@ -193,7 +193,7 @@
 
 - **See also:** [Watchers](../guide/computed.html#watchers)
 
-## \$emit
+## $emit
 
 - **Arguments:**
 
@@ -274,13 +274,13 @@
   - [`emits` option](./options-data.html#emits)
   - [Emitting a Value With an Event](../guide/component-basics.html#emitting-a-value-with-an-event)
 
-## \$forceUpdate
+## $forceUpdate
 
 - **Usage:**
 
   Force the component instance to re-render. Note it does not affect all child components, only the instance itself and child components with inserted slot content.
 
-## \$nextTick
+## $nextTick
 
 - **Arguments:**
 

--- a/src/api/options-data.md
+++ b/src/api/options-data.md
@@ -177,7 +177,7 @@
 
 - **Details:**
 
-  An object where keys are expressions to watch and values are the corresponding callbacks. The value can also be a string of a method name, or an Object that contains additional options. The component instance will call `$watch()` for each entry in the object at instantiation. See [\$watch](instance-methods.html#watch) for more information about the `deep`, `immediate` and `flush` options.
+  An object where keys are expressions to watch and values are the corresponding callbacks. The value can also be a string of a method name, or an Object that contains additional options. The component instance will call `$watch()` for each entry in the object at instantiation. See [$watch](instance-methods.html#watch) for more information about the `deep`, `immediate` and `flush` options.
 
 - **Example:**
 

--- a/src/api/options-lifecycle-hooks.md
+++ b/src/api/options-lifecycle-hooks.md
@@ -44,7 +44,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
   Called after the instance has been mounted, where element, passed to `Vue.createApp({}).mount()` is replaced by the newly created `vm.$el`. If the root instance is mounted to an in-document element, `vm.$el` will also be in-document when `mounted` is called.
 
-  Note that `mounted` does **not** guarantee that all child components have also been mounted. If you want to wait until the entire view has been rendered, you can use [vm.\$nextTick](../api/instance-methods.html#nexttick) inside of `mounted`:
+  Note that `mounted` does **not** guarantee that all child components have also been mounted. If you want to wait until the entire view has been rendered, you can use [vm.$nextTick](../api/instance-methods.html#nexttick) inside of `mounted`:
 
   ```js
   mounted() {
@@ -81,7 +81,7 @@ All lifecycle hooks automatically have their `this` context bound to the instanc
 
   The component's DOM will have been updated when this hook is called, so you can perform DOM-dependent operations here. However, in most cases you should avoid changing state inside the hook. To react to state changes, it's usually better to use a [computed property](./options-data.html#computed) or [watcher](./options-data.html#watch) instead.
 
-  Note that `updated` does **not** guarantee that all child components have also been re-rendered. If you want to wait until the entire view has been re-rendered, you can use [vm.\$nextTick](../api/instance-methods.html#nexttick) inside of `updated`:
+  Note that `updated` does **not** guarantee that all child components have also been re-rendered. If you want to wait until the entire view has been re-rendered, you can use [vm.$nextTick](../api/instance-methods.html#nexttick) inside of `updated`:
 
   ```js
   updated() {

--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -196,7 +196,7 @@ Result:
 
 In this case, using the `watch` option allows us to perform an asynchronous operation (accessing an API) and sets a condition for performing this operation. None of that would be possible with a computed property.
 
-In addition to the `watch` option, you can also use the imperative [vm.\$watch API](../api/instance-methods.html#watch).
+In addition to the `watch` option, you can also use the imperative [vm.$watch API](../api/instance-methods.html#watch).
 
 ### Computed vs Watched Property
 


### PR DESCRIPTION
## Description of Problem

It seems that VuePress isn't handling slashes correctly when generating the headings in the sidebar:

![slashes](https://user-images.githubusercontent.com/65301168/103798402-8e929700-5041-11eb-9b4d-246a449c964d.png)

As far as I'm aware those slashes aren't required as `$` doesn't have any special significance in the markdown engine we're using.

## Proposed Solution

I've removed any `\` that appeared before a `$`.

## Additional Information

Some of these slashes were removed previously in 96499101c150c0e13ecb7d2fb10aedb885bc81a2 but they were reintroduced in 363641a13f600cb965ece3fd1c93210826f61a17. I don't know why.