### PR TITLE
Adjust the line breaks in a template syntax example

### DIFF
--- a/src/guide/template-syntax.md
+++ b/src/guide/template-syntax.md
@@ -64,8 +64,11 @@ The `disabled` attribute will be included if `isButtonDisabled` has a truthy val
 So far we've only been binding to simple property keys in our templates. But Vue.js actually supports the full power of JavaScript expressions inside all data bindings:
 
 ```html
-{{ number + 1 }} {{ ok ? 'YES' : 'NO' }} {{ message.split('').reverse().join('')
-}}
+{{ number + 1 }}
+
+{{ ok ? 'YES' : 'NO' }}
+
+{{ message.split('').reverse().join('') }}
 
 <div v-bind:id="'list-' + id"></div>
 ```


### PR DESCRIPTION
The line breaks in one of the examples in `template-syntax.md` have been mangled, making it harder to understand.

This PR puts the example back to how it is in the Vue 2 docs.