### PR TITLE
Reword the introduction and example for application config

### DIFF
--- a/src/api/application-config.md
+++ b/src/api/application-config.md
@@ -1,14 +1,14 @@
 # Application Config
 
-`config` is an object containing Vue application global configurations. You can modify its properties listed below before mounting your application:
+Every Vue application exposes a `config` object that contains the configuration settings for that application:
 
 ```js
 const app = Vue.createApp({})
 
-app.config = {...}
-
-app.mount(...);
+console.log(app.config)
 ```
+
+You can modify its properties, listed below, before mounting your application.
 
 ## errorHandler
 


### PR DESCRIPTION
The original motivation here was to change the example. It showed `app.config = {...}`, which isn't realistic because you can't assign a new object to that property.

I originally considered giving an example of assigning an individual property but couldn't come up with a tidy example. Instead I changed it to log `app.config`, which shows how to access the object but not much else. In that context it no longer made sense to have the `app.mount` line, so I removed that. The sentence that preceded the example then seemed better placed after the example. Finally, I reworded the opening sentence.