### PR TITLE
fix: prevent layout shift and appearance of horizontal scroll

### DIFF
--- a/src/.vuepress/theme/styles/index.styl
+++ b/src/.vuepress/theme/styles/index.styl
@@ -9,6 +9,7 @@ html, body
   padding 0
   margin 0
   background-color #fff
+  overflow-x hidden
 
 body
   font-family $fontPrimary


### PR DESCRIPTION
## Description of Problem
The layout was shifting horizontally because some content passes their parents' width, so there was an annoying horizontal scrollbar showing in the documentation.

## Proposed Solution
Prevent the horizontal overflowing by giving the `overflow-x: hidden` style to the `html, body` selector which fixes the problem and prevents any content from being horizontally shifted.

## Additional Information
