### PR TITLE
Try to prevent Carbon Ads from causing problems

### DIFF
--- a/src/.vuepress/theme/components/CarbonAds.vue
+++ b/src/.vuepress/theme/components/CarbonAds.vue
@@ -28,29 +28,28 @@ export default {
 <style>
 .carbon-ads {
   min-height: 102px;
-  padding: 1.5rem 1.5rem 0;
-  margin-bottom: -0.5rem;
   font-size: 0.75rem;
 
   width: 125px;
   position: fixed;
   z-index: 1;
-  bottom: 22px;
+  bottom: 14px;
   right: 14px;
   padding: 10px;
   border-radius: 4px;
   background-color: rgba(255, 255, 255, 0.8);
-  /* background-color: #fff; */
-  /* font-size: 13px; */
 }
 
-@media screen and (max-width: 1300px) {
+@media screen and (max-width: 1376px) {
   .carbon-ads {
     position: relative;
-    top: 87px;
-    right: 12px;
+    bottom: auto;
+    right: auto;
+
     float: right;
-    padding: 0 0 20px 30px;
+    margin: 71px 12px 0 15px;
+    padding: 0 0 10px 10px;
+    z-index: 5;
   }
 }
 
@@ -60,14 +59,9 @@ export default {
   display: inline;
 }
 
-.carbon-ads .carbon-img {
-  float: left;
-  margin-right: 1rem;
-  border: 1px solid var(--border-color);
-}
-
 .carbon-ads .carbon-img img {
   display: block;
+  width: 125px;
 }
 
 .carbon-ads .carbon-poweredby {

--- a/src/.vuepress/theme/layouts/Layout.vue
+++ b/src/.vuepress/theme/layouts/Layout.vue
@@ -155,19 +155,3 @@ export default {
   }
 }
 </script>
-
-<style>
-/* add a placeholder to give space to ads so they don't overlap with content */
-@media screen and (max-width: 1376px) {
-  .content__default::before {
-    content: '';
-    position: relative;
-    display: block;
-    float: right;
-    height: 221px;
-    padding: 0 0 20px 30px;
-    margin-top: 20px;
-    margin-right: -24px;
-  }
-}
-</style>


### PR DESCRIPTION
## Description of Problem

The initial problem was the horizontal scrollbar, reported in #793. This would appear below 1300px or 1367px width, depending on the page.

I've also tried to fix edge cases that could occur when the ad overlapped content. In the picture below, the text should not be obscured by the ad:

![overlap](https://user-images.githubusercontent.com/65301168/104111042-bd28a000-52d5-11eb-84fc-04e0861f9702.png)

In this picture, the text `js` should be behind the ad but it is on top instead:

![code language overlap](https://user-images.githubusercontent.com/65301168/104111075-23adbe00-52d6-11eb-8664-d63125ab532c.png)

## Proposed Solution

I've removed the CSS from `Layout.vue`. That attempted to create a placeholder but it wasn't necessary. So long as the ad uses margins for positioning, rather than relative positioning, it will push text out of the way without needing the placeholder.

I've bumped up the `z-index` to `5` so that the ad appears in front of the language when it overlaps code examples. This is only applied conditionally so that it won't overlap the PWA popup.

I've given the image a fixed width of `125px`. The Vue 2 docs seem to do the same thing. Without that the image has a width of `130px`, which slightly overflows the box we've given it.

I've changed the media query threshold from `1300px` to `1376px`. That seems to be the correct value for switching modes. `Layout.vue` already had it set to `1376px`, though that code is now removed.

I've made various small tweaks to the CSS to try to remove unnecessary code.