### PR TITLE
Wrap unintended template syntax with `v-pre`

### DIFF
--- a/src/guide/component-slots.md
+++ b/src/guide/component-slots.md
@@ -247,7 +247,7 @@ app.component('todo-list', {
 })
 ```
 
-We might want to replace the `{{ item }}` with a `<slot>` to customize it on parent component:
+We might want to replace the <span v-pre>`{{ item }}`</span> with a `<slot>` to customize it on parent component:
 
 ```html
 <todo-list>
@@ -320,7 +320,7 @@ Note that the abbreviated syntax for default slot **cannot** be mixed with named
 <todo-list v-slot="slotProps">
   <i class="fas fa-check"></i>
   <span class="green">{{ slotProps.item }}</span>
-  
+
   <template v-slot:other="otherSlotProps">
     slotProps is NOT available here
   </template>


### PR DESCRIPTION
## Description of Problem

I made a suggestion in #763 that has introduced a problem. The sequence:

```text
`{{ item }}`
```

was supposed to be rendered literally. However, VuePress allows for Vue template syntax within the markdown and only code blocks are exempt. Inline code, surrounded by single backticks, is still be treated as a template.

## Proposed Solution

I've wrapped the code in a `<span v-pre>`.

Another alternative would have been to write it as:

```text
`{{ '\u007b\u007b item \u007d\u007d' }}`
```

That avoids the extra element but on balance I felt using `v-pre` would be easier to understand.