### PR TITLE
v-model: Clarify IME caveat tip

### DIFF
--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -16,7 +16,7 @@ You can use the `v-model` directive to create two-way data bindings on form inpu
 
 <span id="vmodel-ime-tip"></span>
 ::: tip Note
-For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) (Chinese, Japanese, Korean etc.), you'll notice that `v-model` doesn't get updated during IME composition. If you want to cater for these updates as well, use `input` event instead.
+For languages that require an [IME](https://en.wikipedia.org/wiki/Input_method) (Chinese, Japanese, Korean etc.), you'll notice that `v-model` doesn't get updated during IME composition. If you want to respond to these updates as well, use an `input` event listener and `value` binding instead of using `v-model`.
 :::
 
 ### Text


### PR DESCRIPTION
## Description of Problem

The tip on using `input` to listen to IME-based composition input was unclear. In the context of the preceding statement about `textarea` and `input type=text` elements using `input`, it seemed that composition with v-model should work with those inputs.

## Proposed Solution

This change makes it clear that `v-model` should be replaced with a custom `@input/:value` pair.

## Additional Information

See [this comment](https://github.com/vuejs/vue/issues/9777#issuecomment-478831263) where @yyx990803 mentions this solution.

See also [this pull request](https://github.com/vuejs/vue/pull/9814) to add a `.eager` feature that would simplify this.