### PR TITLE
feat: add unwrap example code to reactive

### DIFF
--- a/src/api/basic-reactivity.md
+++ b/src/api/basic-reactivity.md
@@ -18,6 +18,31 @@ The reactive conversion is "deep"—it affects all nested properties. In the [ES
 function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 ```
 
+::: warning
+`reactive` will unwrap all the deep [ref](./refs-api.html#ref), while maintaining the [ref](./refs-api.html#ref) reactivity
+
+```ts
+const count = ref(1)
+const obj = reactive({ count })
+
+// ref will be unwrapped
+obj.count === count.value
+
+// it will update `obj.value`
+count.value++
+
+// same value
+obj.count === count.value
+
+// it will also update `count` ref
+obj.count++
+
+// same value
+obj.count === count.value
+```
+
+:::
+
 ## `readonly`
 
 Takes an object (reactive or plain) or a [ref](./refs-api.html#ref) and returns a readonly proxy to the original. A readonly proxy is deep: any nested property accessed will be readonly as well.

--- a/src/api/basic-reactivity.md
+++ b/src/api/basic-reactivity.md
@@ -18,33 +18,31 @@ The reactive conversion is "deep"—it affects all nested properties. In the [ES
 function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 ```
 
-::: tip
-`reactive` will unwrap all the deep [ref](./refs-api.html#ref), while maintaining the [ref](./refs-api.html#ref) reactivity
+::: tip Note
+`reactive` will unwrap all the deep [refs](./refs-api.html#ref), while maintaining the ref reactivity
 
 ```ts
 const count = ref(1)
 const obj = reactive({ count })
 
 // ref will be unwrapped
-obj.count === count.value
+console.log(obj.count === count.value) // true
 
 // it will update `obj.value`
 count.value++
-
-// same value
-obj.count === count.value
+console.log(count.value) // 2
+console.log(obj.count) // 2
 
 // it will also update `count` ref
 obj.count++
-
-// same value
-obj.count === count.value
+console.log(obj.count) // 3
+console.log(count.value) // 3
 ```
 
 :::
 
-::: warning
-When assiging a [ref](./refs-api.html#ref) to a `reactive` property, that [ref](./refs-api.html#ref) will be automatically unwrapped.
+::: warning Important
+When assigning a [ref](./refs-api.html#ref) to a `reactive` property, that ref will be automatically unwrapped.
 
 ```ts
 const count = ref(1)
@@ -52,10 +50,8 @@ const obj = reactive({})
 
 obj.count = count
 
-obj.count // 1
-
-// ref will be unwrapped
-obj.count === count.value
+console.log(obj.count) // 1
+console.log(obj.count === count.value) // true
 ```
 
 :::

--- a/src/api/basic-reactivity.md
+++ b/src/api/basic-reactivity.md
@@ -18,7 +18,7 @@ The reactive conversion is "deep"—it affects all nested properties. In the [ES
 function reactive<T extends object>(target: T): UnwrapNestedRefs<T>
 ```
 
-::: warning
+::: tip
 `reactive` will unwrap all the deep [ref](./refs-api.html#ref), while maintaining the [ref](./refs-api.html#ref) reactivity
 
 ```ts
@@ -38,6 +38,23 @@ obj.count === count.value
 obj.count++
 
 // same value
+obj.count === count.value
+```
+
+:::
+
+::: warning
+When assiging a [ref](./refs-api.html#ref) to a `reactive` property, that [ref](./refs-api.html#ref) will be automatically unwrapped.
+
+```ts
+const count = ref(1)
+const obj = reactive({})
+
+obj.count = count
+
+obj.count // 1
+
+// ref will be unwrapped
 obj.count === count.value
 ```
 


### PR DESCRIPTION
## Description of Problem

No example on how the unwrapping works when assigning a `ref`

## Proposed Solution

Add a warning since it might be a pitfall if someone is expecting to access the `ref` with `.value` when assigning to a reactive 

## Additional Information

This functionality might be referenced else where, but without any clear example (if I recall correctly)