### PR TITLE
Refactor the effect on the sponsors and fix a position caching bug

### DIFF
--- a/src/.vuepress/theme/components/Home.vue
+++ b/src/.vuepress/theme/components/Home.vue
@@ -39,7 +39,7 @@
 
     <Content class="theme-default-content custom" />
 
-    <section class="section-sponsors" ref="sponsors">
+    <section class="section-sponsors" :class="{ active: sponsorsActive }" ref="sponsors">
       <div class="inner">
         <PatreonSponsors :sponsors="sponsors" />
         <OpenCollectiveSponsors />
@@ -85,7 +85,8 @@ export default {
   },
 
   data: () => ({
-    sponsors
+    sponsors,
+    sponsorsActive: false
   }),
 
   computed: {
@@ -103,29 +104,19 @@ export default {
   },
 
   mounted() {
-    if (!window) {
-      return
+    window.addEventListener('scroll', this.onPageScroll)
+  },
+
+  beforeDestroy() {
+    window.removeEventListener('scroll', this.onPageScroll)
+  },
+
+  methods: {
+    onPageScroll() {
+      const sponsorTop = this.$refs.sponsors.offsetTop
+
+      this.sponsorsActive = window.pageYOffset > sponsorTop - 100
     }
-
-    const sponsors = this.$refs.sponsors
-    let sponsorTop = sponsors.offsetTop
-    let sponsorActive = false
-
-    window.addEventListener('resize', () => (sponsorTop = sponsors.offsetTop))
-
-    window.addEventListener('scroll', () => {
-      if (window.pageYOffset > sponsorTop - 100) {
-        if (!sponsorActive) {
-          sponsorActive = true
-          sponsors.classList.add('active')
-        }
-      } else {
-        if (sponsorActive) {
-          sponsorActive = false
-          sponsors.classList.remove('active')
-        }
-      }
-    })
   }
 }
 </script>


### PR DESCRIPTION
I was investigating #195. This doesn't necessarily fix all the problems reported there but it may help.

The Patreon Sponsors on the homepage are shown in grayscale until the page has scrolled to a certain point. I made the following observations:

1. The cached value for `sponsorTop` is not always correct. Elements can move when content loads, it doesn't require a page `resize` for things to move. This could be why #195 observed the transition occurring in a strange place.
2. The listeners were never removed. This didn't actually cause any errors but they do leak when you navigate away to a different page.
3. The code directly manipulates DOM elements rather than using Vue to perform the updates.
4. I don't know why there's a check for `window`. The hook is called during SSR so that shouldn't be necessary.

I've refactored it to use Vue in a more idiomatic way. This also removed a big chunk of the code. The caching of `sponsorTop` is gone and the listener is removed when leaving the page.

I don't believe there was any significant performance benefit from caching the `offsetTop` value. Style recalcs and page reflows shouldn't be a factor here.

Aside from fixing the caching bug, I have not changed the point at which the transition occurs or the speed of the transition.