### PR TITLE
Document why watched template refs require the`flush: 'post'` option to be set

### DIFF
--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -105,8 +105,8 @@ But a key difference to lifecycle hooks is that `watch()` and `watchEffect()` ef
       const root = ref(null)
 
       watchEffect(() => {
-        // This effect runs before the dom is updated,
-        // and consequently, the template ref does not hold a reference to the element yet.
+        // This effect runs before the DOM is updated, and consequently, 
+        // the template ref does not hold a reference to the element yet.
         console.log(root.value) // => null
       })
 

--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -85,3 +85,66 @@ Composition API template refs do not have special handling when used inside `v-f
   }
 </script>
 ```
+
+## Watching Template Refs
+
+Watching a template ref for changes can be an alternative to the use of lifecycle hooks that was demonstrated in the previous examples.
+
+But a key difference to lifecycle hooks is that `watch()` and `watchEffect()` effects are run *before* the DOM is mounted or updated so the template ref hasn't been updated when the watcher runs the effect:
+
+```js
+<template>
+  <div ref="root">This is a root element</div>
+</template>
+
+<script>
+  import { ref, watchEffect } from 'vue'
+
+  export default {
+    setup() {
+      const root = ref(null)
+
+      watchEffect(() => {
+        // This effect runs before the dom is updated,
+        // and consequently, the template ref does not hold a reference to the element yet.
+        console.log(root.value) // => undefined
+      })
+
+      return {
+        root
+      }
+    }
+  }
+</script>
+```
+
+Therefore, watchers that use template refs should be defined with the `flush: 'post'` option. This will run the effect *after* the DOM has been updated and ensure that the template ref stays in sync with the DOM and references the correct element.
+
+```js
+<template>
+  <div ref="root">This is a root element</div>
+</template>
+
+<script>
+  import { ref, watchEffect } from 'vue'
+
+  export default {
+    setup() {
+      const root = ref(null)
+
+      watchEffect(() => {
+        console.log(root.value) // => <div></div>
+      }, 
+      {
+        flush:'post'
+      })
+
+      return {
+        root
+      }
+    }
+  }
+</script>
+```
+
+* See also: [Computed and Watchers](./computed-and-watchers.md#effect-flush-timing)

--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -136,7 +136,7 @@ Therefore, watchers that use template refs should be defined with the `flush: 'p
         console.log(root.value) // => <div></div>
       }, 
       {
-        flush:'post'
+        flush: 'post'
       })
 
       return {

--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -107,7 +107,7 @@ But a key difference to lifecycle hooks is that `watch()` and `watchEffect()` ef
       watchEffect(() => {
         // This effect runs before the dom is updated,
         // and consequently, the template ref does not hold a reference to the element yet.
-        console.log(root.value) // => undefined
+        console.log(root.value) // => null
       })
 
       return {

--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -147,4 +147,4 @@ Therefore, watchers that use template refs should be defined with the `flush: 'p
 </script>
 ```
 
-* See also: [Computed and Watchers](./computed-and-watchers.md#effect-flush-timing)
+* See also: [Computed and Watchers](./reactivity-computed-watchers.html#effect-flush-timing)

--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -120,7 +120,7 @@ But a key difference to lifecycle hooks is that `watch()` and `watchEffect()` ef
 
 Therefore, watchers that use template refs should be defined with the `flush: 'post'` option. This will run the effect *after* the DOM has been updated and ensure that the template ref stays in sync with the DOM and references the correct element.
 
-```js
+```vue
 <template>
   <div ref="root">This is a root element</div>
 </template>

--- a/src/guide/composition-api-template-refs.md
+++ b/src/guide/composition-api-template-refs.md
@@ -92,7 +92,7 @@ Watching a template ref for changes can be an alternative to the use of lifecycl
 
 But a key difference to lifecycle hooks is that `watch()` and `watchEffect()` effects are run *before* the DOM is mounted or updated so the template ref hasn't been updated when the watcher runs the effect:
 
-```js
+```vue
 <template>
   <div ref="root">This is a root element</div>
 </template>

--- a/src/guide/reactivity-computed-watchers.md
+++ b/src/guide/reactivity-computed-watchers.md
@@ -123,7 +123,7 @@ In this example:
 - The count will be logged synchronously on initial run.
 - When `count` is mutated, the callback will be called **before** the component has updated.
 
-In cases where a watcher effect needs to be re-run **after** component updates, we can pass an additional `options` object with the `flush` option (default is `'pre'`):
+In cases where a watcher effect needs to be re-run **after** component updates (i.e. when working with [Template Refs](./composition-api-template-refs.md#watching-template-refs)), we can pass an additional `options` object with the `flush` option (default is `'pre'`):
 
 ```js
 // fire after component updates so you can access the updated DOM


### PR DESCRIPTION
## Description of Problem

- Watchers are flushed before DOM updated by default (`flush: 'pre'`)
- Template Refs are udpated after DOM updates
- So when watching a template ref, `flush: 'post'` has to be used in order to get a correct element reference at all times.

## Proposed Solution

- Add a new section in the chapter on template refs about this, with an example.
- Link to this new section from the "Effect Flush Timing" section in the Reactivtiy docs.

## Additional Information

- This behaviour is unintuitive and has been reported as a bug in vue-next multiple times, see for example: https://github.com/vuejs/vue-next/issues/3030
