### PR TITLE
Add an API entry for mergeProps

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -451,3 +451,26 @@ const app = createApp({
 ```
 
 **See also**: [`$nextTick` instance method](instance-methods.html#nexttick)
+
+## mergeProps
+
+Takes multiple objects containing VNode props and merges them into a single object. A newly created object is returned, the objects passed as arguments are not modified.
+
+Any number of objects can be passed, with properties from later arguments taking precedence. Event listeners are handled specially, as are `class` and `style`, with the values of these properties being merged rather than overwritten.
+
+```js
+import { h, mergeProps } from 'vue'
+
+export default {
+  inheritAttrs: false,
+
+  render() {
+    const props = mergeProps({
+      // The class will be merged with any class from $attrs
+      class: 'active'
+    }, this.$attrs)
+
+    return h('div', props)
+  }
+}
+```


### PR DESCRIPTION
Closes #418.

`mergeProps` is discussed in an RFC here:

https://github.com/vuejs/rfcs/blob/master/active-rfcs/0031-attr-fallthrough.md#in-render-functions

It appears from that description that it is intended to be part of the public API.

I've added an entry to `global-api.md`.

I've based the layout for this entry on the entry for `nextTick`. Personally, I prefer the style used on the Instance Methods page but none of the functions on this page are documented that way.

Rendered: https://deploy-preview-817--vue-docs-next-preview.netlify.app/api/global-api.html#mergeprops