### PR TITLE
docs: updating guidance for conditional class application

### DIFF
--- a/src/guide/class-and-style.md
+++ b/src/guide/class-and-style.md
@@ -111,7 +111,7 @@ If you would like to also toggle a class in the list conditionally, you can do i
 <div :class="[isActive ? activeClass : '', errorClass]"></div>
 ```
 
-This will always apply `errorClass`, but will only apply `activeClass` when `isActive` is truthy.
+This will always apply `errorClass`, but `activeClass` will only be applied when `isActive` is truthy.
 
 However, this can be a bit verbose if you have multiple conditional classes. That's why it's also possible to use the object syntax inside array syntax:
 


### PR DESCRIPTION
## Description of Problem
The guidance for using conditional classes is a little bit misleading as the following:
```html
<div :class="[isActive ? activeClass : '', errorClass]"></div>
```
'This will always apply `errorClass`, but will only apply `activeClass` when `isActive`is truthy.'

Can be misinterpreted as:
'This will always apply `errorClass`, however when `isActive` is truthy, it will ONLY apply `activeClass` and nothing else.'

I personally had to take time to test the code myself in order to verify the actual behaviour, which should not be a requirement for documentation readers.

## Proposed Solution
I renamed the above to:
'This will always apply `errorClass`, but `activeClass` will only be applied when `isActive` is truthy.'