### PR TITLE
Add useCssModule

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -474,3 +474,47 @@ export default {
   }
 }
 ```
+
+## useCssModule
+
+:::warning
+`useCssModule` can only be used within `render` or `setup` functions.
+:::
+
+Allows CSS modules to be accessed within the [`setup`](/api/composition-api.html#setup) function of a [single-file component](/guide/single-file-component.html):
+
+```vue
+<script>
+import { h, useCssModule } from 'vue'
+
+export default {
+  setup () {
+    const style = useCssModule()
+
+    return () => h('div', {
+      class: style.success
+    }, 'Task complete!')
+  }
+}
+</script>
+
+<style module>
+.success {
+  color: #090;
+}
+</style>
+```
+
+For more information about using CSS modules, see [Vue Loader - CSS Modules](https://vue-loader.vuejs.org/guide/css-modules.html).
+
+### Arguments
+
+Accepts one argument: `name`
+
+#### name
+
+- **Type:** `String`
+
+- **Details:**
+
+  The name of the CSS module. Defaults to `'$style'`.


### PR DESCRIPTION
## Description of Problem

`useCssModule` is not documented.

Most aspects of using CSS modules are documented as part of Vue Loader, rather than the core of Vue itself. However, `useCssModule` is imported directly from `vue` as part of the global API.

## Proposed Solution

Add an API reference entry.

Rendered: https://deploy-preview-833--vue-docs-next-preview.netlify.app/api/global-api.html#usecssmodule

## Additional Information

Issue #476 is related.

I haven't documented `useCssVars`. I'm unclear whether that is even officially supported yet as the only official acknowledgement of it that I can find is in an unmerged RFC: https://github.com/vuejs/rfcs/blob/style-vars-2/active-rfcs/0000-sfc-style-variables.md.