### PR TITLE
Correct a couple of typos in reactivity-fundamentals.md

### DIFF
--- a/src/guide/reactivity-fundamentals.md
+++ b/src/guide/reactivity-fundamentals.md
@@ -73,15 +73,15 @@ When a ref is returned as a property on the render context (the object returned 
 </script>
 ```
 
-::tip
-  If you don't need to access the actual object instance, you can wrap it in a reactive:
+:::tip
+If you don't need to access the actual object instance, you can wrap it in a `reactive`:
 
-  ```js
-  rested: reactive({
-    count
-  })
-  ```
-::
+```js
+nested: reactive({
+  count
+})
+```
+:::
 
 ### Access in Reactive Objects
 


### PR DESCRIPTION
There was a typo in the word `nested`.

`::` was used to introduce a tip, which doesn't work. There need to be 3 colons.