### PR TITLE
Enhance errorHandler docs

### DIFF
--- a/src/api/application-config.md
+++ b/src/api/application-config.md
@@ -26,7 +26,7 @@ app.config.errorHandler = (err, vm, info) => {
 }
 ```
 
-Assign a handler for uncaught errors during component render function and watchers. The handler gets called with the error and the application instance.
+Assign a handler for uncaught errors during component render function and watchers (but **not** those coming from instance methods). The handler gets called with the error, the application instance and Vue specific error info.
 
 > Error tracking services [Sentry](https://sentry.io/for/vue/) and [Bugsnag](https://docs.bugsnag.com/platforms/browsers/vue/) provide official integrations using this option.
 


### PR DESCRIPTION
## Description of Problem
A user (me!) can mistakenly expect `errorHandler` to be invoked by errors originating from instance methods. This is not the case.

The situation is well [described here](https://stackoverflow.com/a/49215338/1446845) and has interactive examples.

## Proposed Solution

Explicitly state that instance methods errors won't be handled by errorHandler.

## Additional Information
I also stated the extra `info` argument that is available to the consumer.

---

If this is all good and approved I can port this to the v2 docs as well.
Thanks for reviewing.
