### PR TITLE
Add an example of using defineComponent in a single-file component

### DIFF
--- a/src/guide/typescript-support.md
+++ b/src/guide/typescript-support.md
@@ -102,6 +102,18 @@ const Component = defineComponent({
 })
 ```
 
+If you're using [single-file components](/guide/single-file-component.html) then this would typically be written as:
+
+```vue
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  // type inference enabled
+})
+</script>
+```
+
 ## Using with Options API
 
 TypeScript should be able to infer most of the types without defining types explicitly. For example, if you have a component with a number `count` property, you will have an error if you try to call a string-specific method on it:


### PR DESCRIPTION
The current example that introduces `defineComponent` is not using an SFC. This seems to be causing some confusion, so I've added an extra example that shows the SFC equivalent. The jump from `const Component = ` to `export default` seems to be one that beginners struggle to make when referring to this page of the docs (based on what I've observed on Discord).

SFCs are already discussed earlier on the page, so this isn't introducing a new concept.

I would also note that the two examples at the bottom of the page suddenly switch to using `export default`. While that doesn't necessarily mean they are SFCs, I think that switch is potentially confusing for anyone trying to follow along. I don't know whether my new example helps much but at least it establishes `export default` as a relevant concept.