### PR TITLE
Added `propsData` to migration guide

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -194,6 +194,7 @@ const sidebar = {
         '/guide/migration/key-attribute',
         '/guide/migration/keycode-modifiers',
         '/guide/migration/listeners-removed',
+        '/guide/migration/props-data',
         '/guide/migration/props-default-this',
         '/guide/migration/render-function-api',
         '/guide/migration/slots-unification',

--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -110,10 +110,11 @@ The following consists a list of breaking changes from 2.x:
 ### Removed APIs
 
 - [`keyCode` support as `v-on` modifiers](/guide/migration/keycode-modifiers.html)
-- [$on, $off and $once instance methods](/guide/migration/events-api.html)
+- [$on, $off and \$once instance methods](/guide/migration/events-api.html)
 - [Filters](/guide/migration/filters.html)
 - [Inline templates attributes](/guide/migration/inline-template-attribute.html)
-- [`$children` instance property](/guide/migration/children.md)
+- [`$children` instance property](/guide/migration/children.html)
+- [`propsData` option](/guide/migration/props-data.html)
 - `$destroy` instance method. Users should no longer manually manage the lifecycle of individual Vue components.
 
 ## Supporting Libraries

--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -110,7 +110,7 @@ The following consists a list of breaking changes from 2.x:
 ### Removed APIs
 
 - [`keyCode` support as `v-on` modifiers](/guide/migration/keycode-modifiers.html)
-- [$on, $off and \$once instance methods](/guide/migration/events-api.html)
+- [$on, $off and $once instance methods](/guide/migration/events-api.html)
 - [Filters](/guide/migration/filters.html)
 - [Inline templates attributes](/guide/migration/inline-template-attribute.html)
 - [`$children` instance property](/guide/migration/children.html)

--- a/src/guide/migration/props-data.md
+++ b/src/guide/migration/props-data.md
@@ -1,9 +1,9 @@
 ---
 badges:
-  - breaking
+  - removed
 ---
 
-# `propsData` passed on instance creation <MigrationBadges :badges="$frontmatter.badges" />
+# `propsData` <MigrationBadges :badges="$frontmatter.badges" />
 
 ## Overview
 

--- a/src/guide/migration/props-data.md
+++ b/src/guide/migration/props-data.md
@@ -7,7 +7,7 @@ badges:
 
 ## Overview
 
-`propsData` option to pass props to Vue instance during its creation is removed. To pass props to the root of Vue application, use a second argument of [createApp](/api/global-api.html#createapp)
+The `propsData` option, used to pass props to the Vue instance during its creation, is removed. To pass props to the root component of a Vue 3 application, use the second argument of [createApp](/api/global-api.html#createapp).
 
 ## 2.x Syntax
 

--- a/src/guide/migration/props-data.md
+++ b/src/guide/migration/props-data.md
@@ -1,0 +1,47 @@
+---
+badges:
+  - breaking
+---
+
+# `propsData` passed on instance creation <MigrationBadges :badges="$frontmatter.badges" />
+
+## Overview
+
+`propsData` option to pass props to Vue instance during its creation is removed. To pass props to the root of Vue application, use a second argument of [createApp](/api/global-api.html#createapp)
+
+## 2.x Syntax
+
+In 2.x, we were able to pass props to Vue instance during its creation:
+
+```js
+const Comp = Vue.extend({
+  props: ['username'],
+  template: '<div>{{ username }}</div>'
+})
+
+new Comp({
+  propsData: {
+    username: 'Evan'
+  }
+})
+```
+
+## 3.x Update
+
+`propsData` option was removed. If you need to pass props to the application instance during its creation, you should use `createApp` second argument:
+
+```js
+const app = createApp(
+  {
+    props: ['username']
+  },
+  { username: 'Evan' }
+)
+```
+
+```html
+<div id="app">
+  <!-- Will display 'Evan' -->
+  {{ username }}
+</div>
+```

--- a/src/guide/migration/props-data.md
+++ b/src/guide/migration/props-data.md
@@ -11,7 +11,7 @@ The `propsData` option, used to pass props to the Vue instance during its creati
 
 ## 2.x Syntax
 
-In 2.x, we were able to pass props to Vue instance during its creation:
+In 2.x, we were able to pass props to a Vue instance during its creation:
 
 ```js
 const Comp = Vue.extend({

--- a/src/guide/migration/props-data.md
+++ b/src/guide/migration/props-data.md
@@ -33,15 +33,9 @@ The `propsData` option has been removed. If you need to pass props to the root c
 ```js
 const app = createApp(
   {
-    props: ['username']
+    props: ['username'],
+    template: '<div>{{ username }}</div>'
   },
   { username: 'Evan' }
 )
-```
-
-```html
-<div id="app">
-  <!-- Will display 'Evan' -->
-  {{ username }}
-</div>
 ```

--- a/src/guide/migration/props-data.md
+++ b/src/guide/migration/props-data.md
@@ -28,7 +28,7 @@ new Comp({
 
 ## 3.x Update
 
-`propsData` option was removed. If you need to pass props to the application instance during its creation, you should use `createApp` second argument:
+The `propsData` option has been removed. If you need to pass props to the root component instance during its creation, you should use the second argument of `createApp`:
 
 ```js
 const app = createApp(


### PR DESCRIPTION
## Description of Problem

Currently, we don't reflect in the Migration guide that `propsData` option was removed. This PR aims to fix this

Close https://github.com/vuejs/docs-next/issues/848