### PR TITLE
chore(installation): unify and fix some markdown styles

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -115,14 +115,14 @@ In the [`dist/` directory of the npm package](https://cdn.jsdelivr.net/npm/vue@3
 Global builds are not [UMD](https://github.com/umdjs/umd) builds. They are built as [IIFEs](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) and are only meant for direct use via `<script src="...">`.
 :::
 
-#### vue(.runtime).esm-browser(.prod).js:
+#### `vue(.runtime).esm-browser(.prod).js`:
 
 - For usage via native ES modules imports (in browser via `<script type="module">`.
 - Shares the same runtime compilation, dependency inlining and hard-coded prod/dev behavior with the global build.
 
 ### With a Bundler
 
-#### vue(.runtime).esm-bundler.js:
+#### `vue(.runtime).esm-bundler.js`:
 
 - For use with bundlers like `webpack`, `rollup` and `parcel`.
 - Leaves prod/dev branches with `process.env.NODE_ENV guards` (must be replaced by bundler)

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -90,7 +90,8 @@ $ cd <project-name>
 $ yarn
 $ yarn dev
 ```
-It might occur, that when your username has a space in it like 'Mike Baker' that vite cannot succeed. Have a try with 
+
+It might occur, that when your username has a space in it like 'Mike Baker' that vite cannot succeed. Have a try with
 
 ```bash
 $ create-vite-app <project-name>


### PR DESCRIPTION
- unify to use backquotes for `h4` in the section "Explanation of Different Builds"
- remove some markdown linter warnings:
  - [MD009 Trailing spaces](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md009)
  - [MD031 Fenced code blocks should be surrounded by blank lines](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/doc/Rules.md#md031)