### PR TITLE
Switch the reactivity/proxies CodePen to the Vue account

### DIFF
--- a/src/guide/reactivity.md
+++ b/src/guide/reactivity.md
@@ -44,7 +44,7 @@ So how would we do this in JavaScript?
 When you pass a plain JavaScript object to an application or component instance as its `data` option, Vue will walk through all of its properties and convert them to [Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) using a handler with getters and setters. This is an ES6-only feature, but we offer a version of Vue 3 that uses the older `Object.defineProperty` to support IE browsers. Both have the same surface API, but the Proxy version is slimmer and offers improved performance.
 
 <div class="reactivecontent">
-  <common-codepen-snippet title="Proxies and Vue's Reactivity Explained Visually" slug="zYYzjBg" tab="result" theme="light" :height="500" :team="false" user="sdras" name="Sarah Drasner" :editable="false" :preview="false" />
+  <common-codepen-snippet title="Proxies and Vue's Reactivity Explained Visually" slug="VwmxZXJ" tab="result" theme="light" :height="500" :editable="false" :preview="false" />
 </div>
 
 That was rather quick and requires some knowledge of [Proxies](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) to understand! So let’s dive in a bit. There’s a lot of literature on Proxies, but what you really need to know is that a **Proxy is an object that encases another object or function and allows you to intercept it.**


### PR DESCRIPTION
Fixes #761.

I've migrated this CodePen to the main Vue account, fixing a couple of problems in the process.

Previously, clicking the green Replay button at the end would fail (see #761). This attempted to reload the iframe, which for various reasons doesn't work. I tried some direct replacements but none of those seemed any better.

Instead I tweaked the code to perform a manual reset. Most of the code was already wrapped in functions but I wrapped the remaining code in a function called `init`. I also grabbed the initial `innerHTML` for the main content. Clicking the Replay button now sets the `innerHTML` back to its initial value before rerunning all the same functions that are run when the page first loads.

I also adjusted one of the CSS `height` values from `400px` to `320px`. Previously I was seeing a vertical scrollbar for this example and reducing that value seems to be enough to get rid of it. The animation itself should be unaffected as the extra space was empty.