### PR TITLE
Add self hosting Vue as an option in the installation guide

### DIFF
--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -2,11 +2,12 @@
 
 Vue.js is built by design to be incrementally adoptable. This means that it can be integrated into a project multiple ways depending on the requirements.
 
-There are three primary ways of adding Vue.js to a project:
+There are four primary ways of adding Vue.js to a project:
 
 1. Import it as a [CDN package](#cdn) on the page
-2. Install it using [npm](#npm)
-3. Use the official [CLI](#cli) to scaffold a project, which provides batteries-included build setups for a modern frontend workflow (e.g., hot-reload, lint-on-save, and much more)
+2. Download the JavaScript files and [host them yourself](#download-and-self-host)
+3. Install it using [npm](#npm)
+4. Use the official [CLI](#cli) to scaffold a project, which provides batteries-included build setups for a modern frontend workflow (e.g., hot-reload, lint-on-save, and much more)
 
 ## Release Notes
 
@@ -35,6 +36,12 @@ For prototyping or learning purposes, you can use the latest version with:
 ```
 
 For production, we recommend linking to a specific version number and build to avoid unexpected breakage from newer versions.
+
+## Download and Self Host
+
+If you want to avoid using build tools but can't use a CDN in production then you can download the relevant `.js` file and host it using your own web server. You can then include it using a `<script>` tag, just like with the CDN approach.
+
+The files can be browsed and downloaded from a CDN such as [unpkg](https://unpkg.com/browse/vue@next/dist/) or [jsDelivr](https://cdn.jsdelivr.net/npm/vue@next/dist/). The various different files are [explained later](#explanation-of-different-builds) but you would typically want to download both a development build and a production build.
 
 ## npm
 


### PR DESCRIPTION
Closes #753.

This PR adds a fourth option to the installation guide: downloading the JS file from the CDN and hosting it yourself.