### PR TITLE
Add missing angle brackets to examples in mount-changes.md

### DIFF
--- a/src/guide/migration/mount-changes.md
+++ b/src/guide/migration/mount-changes.md
@@ -23,7 +23,7 @@ new Vue({
     }
   },
   template: `
-    <div id="rendered">{{ message }}</div
+    <div id="rendered">{{ message }}</div>
   `
 })
 
@@ -35,7 +35,7 @@ const app = new Vue({
     }
   },
   template: `
-    <div id="rendered">{{ message }}</div
+    <div id="rendered">{{ message }}</div>
   `
 })
 


### PR DESCRIPTION
A couple of examples in `mount-changes.md` seemed to be missing `>`.