### PR TITLE
Add an emits option to style guide examples that use $emit

### DIFF
--- a/src/style-guide/README.md
+++ b/src/style-guide/README.md
@@ -1583,6 +1583,8 @@ app.component('TodoItem', {
     }
   },
 
+  emits: ['input'],
+
   template: `
     <input
       :value="todo.text"
@@ -1600,6 +1602,8 @@ app.component('TodoItem', {
       required: true
     }
   },
+
+  emits: ['delete'],
 
   template: `
     <span>


### PR DESCRIPTION
There are two style guide examples that use `$emit`. This PR introduces a corresponding `emits` option for them.

For the first example, with the `input` event, this is a required change to prevent the native event being passed up. The example doesn't work as currently written. This was something I noted in the discussion for #859.

For the second example, it does work without the `emits` but I believe using `emits` would still be considered best practice.