### PR TITLE
Switch the Virtual DOM CodePen to the Vue account

### DIFF
--- a/src/guide/optimizations.md
+++ b/src/guide/optimizations.md
@@ -7,7 +7,7 @@
 Now that we know how watchers are updating the components, you might ask how those changes eventually make it to the DOM! Perhaps you’ve heard of the Virtual DOM before, many frameworks including Vue use this paradigm to make sure our interfaces reflect the changes we’re updating in JavaScript effectively
 
 <div class="reactivecontent">
-  <common-codepen-snippet title="How does the Virtual DOM work?" slug="RwwQapa" tab="result" theme="light" :height="500" :team="false" user="sdras" name="Sarah Drasner" :editable="false" :preview="false" />
+  <common-codepen-snippet title="How does the Virtual DOM work?" slug="KKNJKbw" tab="result" theme="light" :height="500" :editable="false" :preview="false" />
 </div>
 
 We make a copy of the DOM in JavaScript called the Virtual DOM, we do this because touching the DOM with JavaScript is computationally expensive. While performing updates in JavaScript is cheap, finding the required DOM nodes and updating them with JavaScript is expensive. So we batch calls, and change the DOM all at once.


### PR DESCRIPTION
Closes #451.

In addition to migrating the CodePen to the Vue account, I have made the following changes to the Haml. Emphasis mine:

Line 9:

> The virtual DOM **in** is a lightweight JavaScript object, created by this render function

> The virtual DOM is a lightweight JavaScript object, created by this render function

Line 15:

> If we need to update the list items, we do so in **javascript**

> If we need to update the list items, we do so in **JavaScript**

Line 17:

> The Virtual DOM allows us to make performant **update** our UIs!

> The Virtual DOM allows us to make performant **updates to** our UIs!

Line 92:

> = succeed "," do

> = succeed ", **[**" do