### PR TITLE
Use a less ambiguous date format for 'Last updated'

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -462,6 +462,21 @@ module.exports = {
   },
   plugins: [
     [
+      '@vuepress/last-updated',
+      {
+        transformer(timestamp) {
+          const date = new Date(timestamp)
+
+          const digits = [
+            date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate(),
+            date.getUTCHours(), date.getUTCMinutes(), date.getUTCSeconds()
+          ].map(num => String(num).padStart(2, '0'))
+
+          return '{0}-{1}-{2}, {3}:{4}:{5} UTC'.replace(/{(\d)}/g, (_, num) => digits[num])
+        }
+      }
+    ],
+    [
       '@vuepress/pwa',
       {
         serviceWorker: true,


### PR DESCRIPTION
Closes #866.

The current date/time format in the footer of each page is only really appropriate for a US audience. I've switched it to something a little more neutral:

```
2021-03-07, 23:03:47 UTC
```

While there are plenty of locales where this format would not be used in everyday life, it is much easier to guess how to interpret it. It is based on ISO 8601, though I decided going all-in with `2021-03-07T23:03:47Z` would be too confusing.