### PR TITLE
Migration guide: mention the removal of set, delete, $set and $delete

### DIFF
--- a/src/guide/migration/introduction.md
+++ b/src/guide/migration/introduction.md
@@ -117,6 +117,7 @@ The following consists a list of breaking changes from 2.x:
 - [`$children` instance property](/guide/migration/children.html)
 - [`propsData` option](/guide/migration/props-data.html)
 - `$destroy` instance method. Users should no longer manually manage the lifecycle of individual Vue components.
+- Global functions `set` and `delete`, and the instance methods `$set` and `$delete`. They are no longer required with proxy-based change detection.
 
 ## Supporting Libraries
 


### PR DESCRIPTION
Related to #420, though arguably the scope of that issue is much larger than the changes here.

This PR just adds a note to the migration guide that `set`, `delete`, `$set` and `$delete` have been removed.