### PR TITLE
French translation

### DIFF
--- a/src/.vuepress/components/guide/contributing/translations-data.js
+++ b/src/.vuepress/components/guide/contributing/translations-data.js
@@ -12,11 +12,11 @@ export const labels = {
 // You may need to clear your sessionStorage when adding a new item to this list
 export const repos = [
   { lang: 'en-us', owner: 'vuejs', repo: 'docs-next', branch: 'master', url: 'https://v3.vuejs.org/' },
+  { lang: 'fr', owner: 'demahom18', repo: 'docs-next', branch: 'master', url: 'https://vue3-fr.netlify.app' },
   { lang: 'id', owner: 'vuejs-id', repo: 'docs-next', branch: 'indonesian' },
   { lang: 'ja', owner: 'vuejs-jp', repo: 'ja.vuejs.org', branch: 'lang-ja', url: 'https://v3.ja.vuejs.org/' },
   { lang: 'ko', owner: 'vuejs-kr', repo: 'docs-next', branch: 'rootKoKr', url: 'https://v3.ko.vuejs.org/'  },
   { lang: 'pt-br', owner: 'vuejs-br', repo: 'docs-next', branch: 'master', url: 'https://vuejsbr-docs-next.netlify.app/' },
   { lang: 'ru', owner: 'translation-gang', repo: 'docs-next', branch: 'master' },
-  { lang: 'zh-cn', owner: 'vuejs', repo: 'docs-next-zh-cn', branch: 'master', url: 'https://v3.cn.vuejs.org/' },
-  { lang: 'fr', owner: 'demahom18', repo: 'docs-next', branch: 'master', url: 'https://vue3-fr.netlify.app' }
+  { lang: 'zh-cn', owner: 'vuejs', repo: 'docs-next-zh-cn', branch: 'master', url: 'https://v3.cn.vuejs.org/' }
 ]

--- a/src/.vuepress/components/guide/contributing/translations-data.js
+++ b/src/.vuepress/components/guide/contributing/translations-data.js
@@ -17,5 +17,6 @@ export const repos = [
   { lang: 'ko', owner: 'vuejs-kr', repo: 'docs-next', branch: 'rootKoKr', url: 'https://v3.ko.vuejs.org/'  },
   { lang: 'pt-br', owner: 'vuejs-br', repo: 'docs-next', branch: 'master', url: 'https://vuejsbr-docs-next.netlify.app/' },
   { lang: 'ru', owner: 'translation-gang', repo: 'docs-next', branch: 'master' },
-  { lang: 'zh-cn', owner: 'vuejs', repo: 'docs-next-zh-cn', branch: 'master', url: 'https://v3.cn.vuejs.org/' }
+  { lang: 'zh-cn', owner: 'vuejs', repo: 'docs-next-zh-cn', branch: 'master', url: 'https://v3.cn.vuejs.org/' },
+  { lang: 'fr', owner: 'demahom18', repo: 'docs-next', branch: 'master', url: 'https://vue3-fr.netlify.app' }
 ]


### PR DESCRIPTION
Add french translation in the community translation table

It is the first time I'm  contributing to an open source project, so I don't know if I'm doing it the right way.
I translated almost 60% of the documentation in french. 

you can see the deployed site here : https://vue3-fr.netlify.app/
and the repo: github.com/demahom18/docs-next
