### PR TITLE
Convert unexplained variables to arguments in an emits example

### DIFF
--- a/src/guide/component-custom-events.md
+++ b/src/guide/component-custom-events.md
@@ -57,7 +57,7 @@ app.component('custom-form', {
     }
   },
   methods: {
-    submitForm() {
+    submitForm(email, password) {
       this.$emit('submit', { email, password })
     }
   }


### PR DESCRIPTION
This came from a conversation on Discord where someone got confused by this example.

`email` and `password` are used inside the method but it isn't clear where they come from. While making them `data` properties would probably be more realistic, adding them as arguments is a simpler change.