### PR TITLE
Vue 3 vueschool links

### DIFF
--- a/src/guide/class-and-style.md
+++ b/src/guide/class-and-style.md
@@ -3,6 +3,7 @@
 A common need for data binding is manipulating an element's class list and its inline styles. Since they are both attributes, we can use `v-bind` to handle them: we only need to calculate a final string with our expressions. However, meddling with string concatenation is annoying and error-prone. For this reason, Vue provides special enhancements when `v-bind` is used with `class` and `style`. In addition to strings, the expressions can also evaluate to objects or arrays.
 
 ## Binding HTML Classes
+<VideoLesson href="https://vueschool.io/lessons/dynamic-css-classes-with-vue-3?friend=vuejs" title="Free Vue.js Dynamic Classes Lesson">Watch a free video lesson on Vue School</VideoLesson>
 
 ### Object Syntax
 

--- a/src/guide/computed.md
+++ b/src/guide/computed.md
@@ -2,6 +2,8 @@
 
 ## Computed Properties
 
+<VideoLesson href="https://vueschool.io/lessons/computed-properties-in-vue-3?friend=vuejs" title="Learn how computed properties work with Vue School">Learn how computed properties work with a free lesson on Vue School</VideoLesson>
+
 In-template expressions are very convenient, but they are meant for simple operations. Putting too much logic in your templates can make them bloated and hard to maintain. For example, if we have an object with a nested array:
 
 ```js

--- a/src/guide/conditional.md
+++ b/src/guide/conditional.md
@@ -1,5 +1,7 @@
 # Conditional Rendering
 
+<VideoLesson href="https://vueschool.io/lessons/conditional-rendering-in-vue-3?friend=vuejs" title="Learn how conditional rendering works with Vue School">Learn how conditional rendering works with a free lesson on Vue School</VideoLesson>
+
 ## `v-if`
 
 The directive `v-if` is used to conditionally render a block. The block will only be rendered if the directive's expression returns a truthy value.

--- a/src/guide/data-methods.md
+++ b/src/guide/data-methods.md
@@ -1,5 +1,7 @@
 # Data Properties and Methods
 
+<VideoLesson href="https://vueschool.io/lessons/methods-in-vue-3?friend=vuejs" title="Learn how to use methods on Vue School">Learn how to work with data and methods with a free Vue School lesson</VideoLesson>
+
 ## Data Properties
 
 The `data` option for a component is a function. Vue calls this function as part of creating a new component instance. It should return an object, which Vue will then wrap in its reactivity system and store on the component instance as `$data`. For convenience, any top-level properties of that object are also exposed directly via the component instance:

--- a/src/guide/events.md
+++ b/src/guide/events.md
@@ -1,5 +1,7 @@
 # Event Handling
 
+<VideoLesson href="https://vueschool.io/lessons/user-events-in-vue-3?friend=vuejs" title="Learn how to handle events on Vue School">Learn how to handle events in a free Vue School lesson</VideoLesson>
+
 ## Listening to Events
 
 We can use the `v-on` directive, which we typically shorten to the `@` symbol, to listen to DOM events and run some JavaScript when they're triggered. The usage would be `v-on:click="methodName"` or with the shortcut, `@click="methodName"`

--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -1,5 +1,7 @@
 # Form Input Bindings
 
+<VideoLesson href="https://vueschool.io/lessons/user-inputs-vue-devtools-in-vue-3?friend=vuejs" title="Learn how to handle form inputs on Vue School">Learn how to work with form inputs with a free Vue School lesson</VideoLesson>
+
 ## Basic Usage
 
 You can use the `v-model` directive to create two-way data bindings on form input, textarea, and select elements. It automatically picks the correct way to update the element based on the input type. Although a bit magical, `v-model` is essentially syntax sugar for updating data on user input events, plus special care for some edge cases.

--- a/src/guide/installation.md
+++ b/src/guide/installation.md
@@ -18,6 +18,8 @@ Detailed release notes for each version are available on [GitHub](https://github
 ## Vue Devtools
 
 > Currently in Beta - Vuex and Router integration is still WIP
+ 
+<VideoLesson href="https://vueschool.io/lessons/using-vue-dev-tools-with-vuejs-3?friend=vuejs" title="Learn how to install Vue Devtools on Vue School">Learn how to install and use Vue Devtools in a free Vue School lesson</VideoLesson>
 
 When using Vue, we recommend also installing the [Vue Devtools](https://github.com/vuejs/vue-devtools#vue-devtools) in your browser, allowing you to inspect and debug your Vue applications in a more user-friendly interface.
 

--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -1,5 +1,7 @@
 # List Rendering
 
+<VideoLesson href="https://vueschool.io/lessons/list-rendering-in-vue-3?friend=vuejs" title="Learn how to render lists on Vue School">Learn how to render list with a free Vue School lesson</VideoLesson>
+
 ## Mapping an Array to Elements with `v-for`
 
 We can use the `v-for` directive to render a list of items based on an array. The `v-for` directive requires a special syntax in the form of `item in items`, where `items` is the source data array and `item` is an **alias** for the array element being iterated on:


### PR DESCRIPTION
This PR adds Vue School links to the documentation to supplement the documentation with free training videos. 

The lessons are up-to-date, V3 versions of previously approved Vue 2 lessons that were added to the documentation in [PR 2379](https://github.com/vuejs/vuejs.org/pull/2379). As requested in [PR 311](https://github.com/vuejs/docs-next/pull/311)

[Screenshots of the placements can be seen here](https://imgur.com/a/1G4UGNo)

**Lessons**
[Class Binding](https://vueschool.io/lessons/dynamic-css-classes-with-vue-3)
[Event Handling](https://vueschool.io/lessons/user-events-in-vue-3)
[Computed Properties](https://vueschool.io/lessons/computed-properties-in-vue-3)
[Conditional Rendering](https://vueschool.io/lessons/conditional-rendering-in-vue-3)
[List Rendering](https://vueschool.io/lessons/list-rendering-in-vue-3)
[Methods](https://vueschool.io/lessons/methods-in-vue-3)
[Form Input](https://vueschool.io/lessons/user-inputs-vue-devtools-in-vue-3)
[Vue Devtools](https://vueschool.io/lessons/using-vue-dev-tools-with-vuejs-3)