### PR TITLE
Update broken link to the custom element spec

### DIFF
--- a/src/style-guide/README.md
+++ b/src/style-guide/README.md
@@ -38,7 +38,7 @@ Some features of Vue exist to accommodate rare edge cases or smoother migrations
 
 **Component names should always be multi-word, except for root `App` components, and built-in components provided by Vue, such as `<transition>` or `<component>`.**
 
-This [prevents conflicts](http://w3c.github.io/webcomponents/spec/custom/#valid-custom-element-name) with existing and future HTML elements, since all HTML elements are a single word.
+This [prevents conflicts](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) with existing and future HTML elements, since all HTML elements are a single word.
 
 <div class="style-example style-example-bad">
 <h4>Bad</h4>


### PR DESCRIPTION
Closes #974.

An external link in the style guide is giving a 404.

The new link appears to be the same spec based on what I could see on the Wayback Machine. The new URL is already being used in `component-registration.md`.