### PR TITLE
Link vue-router-next in routing page

### DIFF
--- a/src/guide/routing.md
+++ b/src/guide/routing.md
@@ -2,7 +2,7 @@
 
 ## Official Router
 
-For most Single Page Applications, it's recommended to use the officially-supported [vue-router library](https://github.com/vuejs/vue-router). For more details, see vue-router's [documentation](https://next.router.vuejs.org/).
+For most Single Page Applications, it's recommended to use the officially-supported [vue-router library](https://github.com/vuejs/vue-router-next). For more details, see vue-router's [documentation](https://next.router.vuejs.org/).
 
 ## Simple Routing from Scratch
 


### PR DESCRIPTION
## Description of Problem

The link is to the repository of vue-router 3 for Vue 2.

## Proposed Solution

Link the repository of vue-router 4.

## Additional Information
