### PR TITLE
Migrate two example CodePens to the Vue account

### DIFF
--- a/src/examples/elastic-header.md
+++ b/src/examples/elastic-header.md
@@ -1,3 +1,3 @@
 # Elastic Header Example
 
-<common-codepen-snippet title="Vue 3 Elastic Draggable Header Example" slug="ZEWGmar" :height="474" tab="js,result" :team="false" user="immarina" name="Vue" :preview="false" :editable="false" />
+<common-codepen-snippet title="Vue 3 Elastic Draggable Header Example" slug="PoWpdWY" :height="474" tab="js,result" :preview="false" :editable="false" />

--- a/src/examples/markdown.md
+++ b/src/examples/markdown.md
@@ -2,4 +2,4 @@
 
 > A simple Markdown editor
 
-<common-codepen-snippet title="Vue 3 Markdown Editor" slug="oNxXzyB" :height="474" tab="js,result" :team="false" user="immarina" name="Vue" :preview="false" :editable="false" />
+<common-codepen-snippet title="Vue 3 Markdown Editor" slug="poReOvE" :height="474" tab="js,result" :preview="false" :editable="false" />


### PR DESCRIPTION
This PR migrates the Markdown and Elastic Header examples to the Vue CodePen account.

The examples themselves should not have changed.