### PR TITLE
Fix banner bug that also broke the search

### DIFF
--- a/src/.vuepress/theme/layouts/Layout.vue
+++ b/src/.vuepress/theme/layouts/Layout.vue
@@ -134,18 +134,16 @@ export default {
     }
   },
 
-  beforeMount() {
-    this.isBannerOpen = !localStorage.getItem(this.nameStorage)
-  },
-
   mounted() {
     this.$router.afterEach(() => {
       this.isSidebarOpen = false
     })
 
+    this.isBannerOpen = !localStorage.getItem(this.nameStorage)
+
     // Load component according to user preferences
     if (this.isBannerOpen) {
-      this.initBanner()
+      this.$nextTick(this.initBanner)
     }
   },
 


### PR DESCRIPTION
I believe the problem is that hydration fails in production because state gets changed in `beforeMount`.

This not only breaks the Vue Mastery Banner but also the search box.