### PR TITLE
Add Vue.version and app.version to the API reference

### DIFF
--- a/src/api/application-api.md
+++ b/src/api/application-api.md
@@ -316,3 +316,27 @@ setTimeout(() => app.unmount(), 5000)
   ```
 
 - **See also:** [Plugins](../guide/plugins.html)
+
+## version
+
+- **Usage:**
+
+  Provides the installed version of Vue as a string. This is especially useful for community [plugins](/guide/plugins.html), where you might use different strategies for different versions.
+
+- **Example:**
+
+  ```js
+  export default {
+    install(app) {
+      const version = Number(app.version.split('.')[0])
+      
+      if (version < 3) {
+        console.warn('This plugin requires Vue 3')
+      }
+      
+      // ...
+    }
+  }
+  ```
+  
+- **See also**: [Global API - version](/api/global-api.html#version)

--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -532,3 +532,21 @@ Accepts one argument: `name`
 - **Details:**
 
   The name of the CSS module. Defaults to `'$style'`.
+
+## version
+
+Provides the installed version of Vue as a string.
+
+```js
+const version = Number(Vue.version.split('.')[0])
+
+if (version === 3) {
+  // Vue 3
+} else if (version === 2) {
+  // Vue 2
+} else {
+  // Unsupported versions of Vue
+}
+```
+
+**See also**: [Application API - version](/api/application-api.html#version)


### PR DESCRIPTION
Closes #997.

This PR documents `Vue.version` and `app.version` in the API reference. These are two different ways to access the current Vue version.

In Vue 2, we just had `Vue.version`: https://vuejs.org/v2/api/#Vue-version. When interacting with a global `Vue` object, e.g. for CDN usage, the equivalent in Vue 3 would be exactly the same, `Vue.version`.

For plugins, the first argument passed to `install` was previously `Vue`. It's now `app`, which also exposes a `version` property. This allows plugins to check the version using the `version` property of that first argument.

I borrowed much of the wording and example code from the Vue 2 documentation.