### PR TITLE
Remove duplicate word 'returns' from h description

### DIFF
--- a/src/api/global-api.md
+++ b/src/api/global-api.md
@@ -78,7 +78,7 @@ export type CreateAppFunction<HostElement> = (
 
 ## h
 
-Returns a returns "virtual node", usually abbreviated to **VNode**: a plain object which contains information describing to Vue what kind of node it should render on the page, including descriptions of any child nodes. It is intended for manually written [render functions](../guide/render-function.md):
+Returns a "virtual node", usually abbreviated to **VNode**: a plain object which contains information describing to Vue what kind of node it should render on the page, including descriptions of any child nodes. It is intended for manually written [render functions](../guide/render-function.md):
 
 ```js
 render() {


### PR DESCRIPTION
Remove an unnecessary word.

Closes #998.