### PR TITLE
Mixins don't recursively merge data

### DIFF
--- a/src/guide/mixins.md
+++ b/src/guide/mixins.md
@@ -31,7 +31,7 @@ app.mount('#mixins-basic') // => "hello from mixin!"
 
 When a mixin and the component itself contain overlapping options, they will be "merged" using appropriate strategies.
 
-For example, data objects undergo a recursive merge, with the component's data taking priority in cases of conflicts.
+For example, each mixin can have its own `data` function. Each of them will be called, with the returned objects being merged. Properties from the component's own data will take priority in cases of conflicts.
 
 ```js
 const myMixin = {


### PR DESCRIPTION
In Vue 2, `data` from mixins was merged recursively. This is no longer the case in Vue 3:

https://v3.vuejs.org/guide/migration/data-option.html#mixin-merge-behavior-change

I've updated the page about mixins to remove the word 'recursive'. I've also reworded that paragraph to distinguish between the `data` functions and the objects they return.