### PR TITLE
docs: :memo: clarify async components for Vue Router

### DIFF
--- a/src/guide/migration/async-components.md
+++ b/src/guide/migration/async-components.md
@@ -20,14 +20,14 @@ For a more in-depth explanation, read on!
 Previously, async components were created by simply defining a component as a function that returned a promise, such as:
 
 ```js
-const asyncPage = () => import('./NextPage.vue')
+const asyncPage = () => import('./CartFlyout.vue')
 ```
 
 Or, for the more advanced component syntax with options:
 
 ```js
 const asyncPage = {
-  component: () => import('./NextPage.vue'),
+  component: () => import('./CartFlyout.vue'),
   delay: 200,
   timeout: 3000,
   error: ErrorComponent,
@@ -45,11 +45,11 @@ import ErrorComponent from './components/ErrorComponent.vue'
 import LoadingComponent from './components/LoadingComponent.vue'
 
 // Async component without options
-const asyncPage = defineAsyncComponent(() => import('./NextPage.vue'))
+const asyncPage = defineAsyncComponent(() => import('./CartFlyout.vue'))
 
 // Async component with options
 const asyncPageWithOptions = defineAsyncComponent({
-  loader: () => import('./NextPage.vue'),
+  loader: () => import('./CartFlyout.vue'),
   delay: 200,
   timeout: 3000,
   errorComponent: ErrorComponent,
@@ -57,13 +57,17 @@ const asyncPageWithOptions = defineAsyncComponent({
 })
 ```
 
+::: tip NOTE
+When using the official Vue Router and you want to asynchronously load (lazy load) router components, you should not use `defineAsyncComponent`. You can read more about this in the (Lazy Loading Routes)[https://next.router.vuejs.org/guide/advanced/lazy-loading.html#lazy-loading-routes] section of the Vue Router documentation.
+:::
+
 Another change that has been made from 2.x is that the `component` option is now renamed to `loader` in order to accurately communicate that a component definition cannot be provided directly.
 
 ```js{4}
 import { defineAsyncComponent } from 'vue'
 
 const asyncPageWithOptions = defineAsyncComponent({
-  loader: () => import('./NextPage.vue'),
+  loader: () => import('./CartFlyout.vue'),
   delay: 200,
   timeout: 3000,
   errorComponent: ErrorComponent,

--- a/src/guide/migration/async-components.md
+++ b/src/guide/migration/async-components.md
@@ -58,7 +58,7 @@ const asyncPageWithOptions = defineAsyncComponent({
 ```
 
 ::: tip NOTE
-When using the official Vue Router and you want to asynchronously load (lazy load) router components, you should not use `defineAsyncComponent`. You can read more about this in the (Lazy Loading Routes)[https://next.router.vuejs.org/guide/advanced/lazy-loading.html#lazy-loading-routes] section of the Vue Router documentation.
+Vue Router supports a similar mechanism for asynchronously loading route components, known as *lazy loading*. Despite the similarities, this feature is distinct from Vue's support for async components. You should **not** use `defineAsyncComponent` when configuring route components with Vue Router. You can read more about this in the [Lazy Loading Routes](https://next.router.vuejs.org/guide/advanced/lazy-loading.html) section of the Vue Router documentation.
 :::
 
 Another change that has been made from 2.x is that the `component` option is now renamed to `loader` in order to accurately communicate that a component definition cannot be provided directly.

--- a/src/guide/migration/async-components.md
+++ b/src/guide/migration/async-components.md
@@ -20,14 +20,14 @@ For a more in-depth explanation, read on!
 Previously, async components were created by simply defining a component as a function that returned a promise, such as:
 
 ```js
-const asyncPage = () => import('./CartFlyout.vue')
+const asyncModal = () => import('./Modal.vue')
 ```
 
 Or, for the more advanced component syntax with options:
 
 ```js
-const asyncPage = {
-  component: () => import('./CartFlyout.vue'),
+const asyncModal = {
+  component: () => import('./Modal.vue'),
   delay: 200,
   timeout: 3000,
   error: ErrorComponent,
@@ -45,11 +45,11 @@ import ErrorComponent from './components/ErrorComponent.vue'
 import LoadingComponent from './components/LoadingComponent.vue'
 
 // Async component without options
-const asyncPage = defineAsyncComponent(() => import('./CartFlyout.vue'))
+const asyncModal = defineAsyncComponent(() => import('./Modal.vue'))
 
 // Async component with options
-const asyncPageWithOptions = defineAsyncComponent({
-  loader: () => import('./CartFlyout.vue'),
+const asyncModalWithOptions = defineAsyncComponent({
+  loader: () => import('./Modal.vue'),
   delay: 200,
   timeout: 3000,
   errorComponent: ErrorComponent,
@@ -66,8 +66,8 @@ Another change that has been made from 2.x is that the `component` option is now
 ```js{4}
 import { defineAsyncComponent } from 'vue'
 
-const asyncPageWithOptions = defineAsyncComponent({
-  loader: () => import('./CartFlyout.vue'),
+const asyncModalWithOptions = defineAsyncComponent({
+  loader: () => import('./Modal.vue'),
   delay: 200,
   timeout: 3000,
   errorComponent: ErrorComponent,


### PR DESCRIPTION
## Description of Problem
The docs around async components can be a bit confusing when people use Vue Router, hopefully this change clarifies the use of async component with Vue Router a bit.

## Proposed Solution
- Change the example of `NextPage.vue` to a more generic `Modal.vue`
- Add a note about async components and Vue Router, with a link to the relevant section in the Router docs.

## Additional Information
Relates to issue: https://github.com/vuejs/docs-next/issues/1013
