### PR TITLE
Switch javascript code blocks to js

### DIFF
--- a/src/guide/migration/custom-directives.md
+++ b/src/guide/migration/custom-directives.md
@@ -85,7 +85,7 @@ It's generally recommended to keep directives independent of the component insta
 
 In Vue 2, the component instance had to be accessed through the `vnode` argument:
 
-```javascript
+```js
 bind(el, binding, vnode) {
   const vm = vnode.context
 }
@@ -93,7 +93,7 @@ bind(el, binding, vnode) {
 
 In Vue 3, the instance is now part of the `binding`:
 
-```javascript
+```js
 mounted(el, binding, vnode) {
   const vm = binding.instance
 }

--- a/src/guide/migration/filters.md
+++ b/src/guide/migration/filters.md
@@ -79,7 +79,7 @@ If you are using filters that were globally registered and then used throughout 
 
 Instead, you can make your global filters available to all components through [globalProperties](../../api/application-config.html#globalproperties):
 
-```javascript
+```js
 // main.js
 const app = createApp(App)
 

--- a/src/guide/migration/listeners-removed.md
+++ b/src/guide/migration/listeners-removed.md
@@ -10,7 +10,7 @@ badges:
 
 The `$listeners` object has been removed in Vue 3. Event listeners are now part of `$attrs`:
 
-```javascript
+```js
 {
   text: 'this is an attribute',
   onClose: () => console.log('close Event triggered')
@@ -54,7 +54,7 @@ export default {
 
 If this component received an `id` attribute and a `v-on:close` listener, the `$attrs` object will now look like this:
 
-```javascript
+```js
 {
   id: 'my-input',
   onClose: () => console.log('close Event triggered')

--- a/src/guide/render-function.md
+++ b/src/guide/render-function.md
@@ -354,7 +354,7 @@ For the `.passive`, `.capture`, and `.once` event modifiers, they can be concate
 
 For example:
 
-```javascript
+```js
 render() {
   return h('input', {
     onClickCapture: this.doThisInCapturingMode,

--- a/src/guide/single-file-component.md
+++ b/src/guide/single-file-component.md
@@ -90,7 +90,7 @@ touch rollup.config.js
 
 Once the file is created we will need to open it with our editor of choice and add the following code.
 
-```javascript
+```js
 // import our third party plugins
 import commonjs from 'rollup-plugin-commonjs'
 import VuePlugin from 'rollup-plugin-vue'
@@ -144,7 +144,7 @@ Here we are specifying:
 To also build `umd` and `cjs` modules we can simply add a few lines of configuration to our `rollup.config.js` and `package.json`
 
 ##### rollup.config.js 
-```javascript
+```js
 output: [
   ...
    {


### PR DESCRIPTION
A handful of code blocks were using `javascript` for the language instead of `js`. This PR brings them into line with the others. It doesn't make any difference to how VuePress renders them: it shows the language as `js` either way.