### PR TITLE
Tidy up the markdown tables

### DIFF
--- a/src/guide/a11y-basics.md
+++ b/src/guide/a11y-basics.md
@@ -94,16 +94,16 @@ Users can navigate an application through headings. Having descriptive headings 
 
 Landmarks provide programmatic access to sections within an application. Users who rely on assistive technology can navigate to each section of the application and skip over content. You can use [ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles) to help you achieve this.
 
-| HTML            | ARIA Role                                                         | Landmark Purpose                                                                       |
-| --------------- | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| header          | role="banner"                                                     | Prime heading: title of the page                                                       |
-| nav             | role="navigation"                                                 | Collection of links suitable for use when navigating the document or related documents |
-| main            | role="main"                                                       | The main or central content of the document.                                           |
-| footer          | role="contentinfo"                                                | Information about the parent document: footnotes/copyrights/links to privacy statement |
-| aside           | role="complementary"                                              | Supports the main content, yet is separated and meaningful on its own content            |
-| _Not available_ | role="search"                                                     | This section contains the search functionality for the application                     |
-| form            | role="form"                                                       | Collection of form-associated elements                                                 |
-| section         | role="region"  | Content that is relevant and that users will likely want to navigate to. Label must be provided for this element                |
+| HTML            | ARIA Role            | Landmark Purpose                                                                                                 |
+| --------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| header          | role="banner"        | Prime heading: title of the page                                                                                 |
+| nav             | role="navigation"    | Collection of links suitable for use when navigating the document or related documents                           |
+| main            | role="main"          | The main or central content of the document.                                                                     |
+| footer          | role="contentinfo"   | Information about the parent document: footnotes/copyrights/links to privacy statement                           |
+| aside           | role="complementary" | Supports the main content, yet is separated and meaningful on its own content                                    |
+| _Not available_ | role="search"        | This section contains the search functionality for the application                                               |
+| form            | role="form"          | Collection of form-associated elements                                                                           |
+| section         | role="region"        | Content that is relevant and that users will likely want to navigate to. Label must be provided for this element |
 
 :::tip Tip:
 It is recommended to use landmark HTML elements with redundant landmark role attributes in order to maximize compatibility with legacy [browsers that don’t support HTML5 semantic elements](https://caniuse.com/#feat=html5semantic).

--- a/src/guide/composition-api-lifecycle-hooks.md
+++ b/src/guide/composition-api-lifecycle-hooks.md
@@ -9,18 +9,18 @@ You can access a component's lifecycle hook by prefixing the lifecycle hook with
 The following table contains how the lifecycle hooks are invoked inside of [setup()](composition-api-setup.html):
 
 | Options API       | Hook inside `setup` |
-| ----------------- | -------------------------- |
-| `beforeCreate`    | Not needed\*               |
-| `created`         | Not needed\*               |
-| `beforeMount`     | `onBeforeMount`            |
-| `mounted`         | `onMounted`                |
-| `beforeUpdate`    | `onBeforeUpdate`           |
-| `updated`         | `onUpdated`                |
-| `beforeUnmount`   | `onBeforeUnmount`          |
-| `unmounted`       | `onUnmounted`              |
-| `errorCaptured`   | `onErrorCaptured`          |
-| `renderTracked`   | `onRenderTracked`          |
-| `renderTriggered` | `onRenderTriggered`        |
+| ----------------- | ------------------- |
+| `beforeCreate`    | Not needed\*        |
+| `created`         | Not needed\*        |
+| `beforeMount`     | `onBeforeMount`     |
+| `mounted`         | `onMounted`         |
+| `beforeUpdate`    | `onBeforeUpdate`    |
+| `updated`         | `onUpdated`         |
+| `beforeUnmount`   | `onBeforeUnmount`   |
+| `unmounted`       | `onUnmounted`       |
+| `errorCaptured`   | `onErrorCaptured`   |
+| `renderTracked`   | `onRenderTracked`   |
+| `renderTriggered` | `onRenderTriggered` |
 
 :::tip
 Because `setup` is run around the `beforeCreate` and `created` lifecycle hooks, you do not need to explicitly define them. In other words, any code that would be written inside those hooks should be written directly in the `setup` function.

--- a/src/guide/migration/global-api.md
+++ b/src/guide/migration/global-api.md
@@ -84,7 +84,7 @@ An app instance exposes a subset of the Vue 2 global APIs. The rule of thumb is 
 | Vue.directive              | app.directive                                                                                   |
 | Vue.mixin                  | app.mixin                                                                                       |
 | Vue.use                    | app.use ([see below](#a-note-for-plugin-authors))                                               |
-| Vue.prototype              | app.config.globalProperties ([see below](#vue-prototype-replaced-by-config-globalproperties))   |                                                                     |
+| Vue.prototype              | app.config.globalProperties ([see below](#vue-prototype-replaced-by-config-globalproperties))   |
 
 All other global APIs that do not globally mutate behavior are now named exports, as documented in [Global API Treeshaking](./global-api-treeshaking.html).
 


### PR DESCRIPTION
This is another PR based on #1009.

This shouldn't impact the rendered output, it just lines up the columns in the markdown.

`global-api.md` had a rogue, empty column on the final row. It didn't actually render as a column and I've removed it.