### PR TITLE
docs: add automatic global registration to cookbook

### DIFF
--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -6,7 +6,8 @@ const sidebar = {
       children: [
         '/cookbook/',
         '/cookbook/editable-svg-icons',
-        '/cookbook/debugging-in-vscode'
+        '/cookbook/debugging-in-vscode',
+        '/cookbook/automatic-global-registration-of-base-components'
       ]
     }
   ],

--- a/src/cookbook/automatic-global-registration-of-base-components.md
+++ b/src/cookbook/automatic-global-registration-of-base-components.md
@@ -1,0 +1,75 @@
+# Automatic Global Registration of Base Components
+
+## Base Example
+
+Many of your components will be relatively generic, possibly only wrapping an element like an input or a button. We sometimes refer to these as [base components](../style-guide/#Base-component-names-strongly-recommended) and they tend to be used very frequently across your components.
+
+The result is that many components may include long lists of base components:
+
+```js
+import BaseButton from './BaseButton.vue'
+import BaseIcon from './BaseIcon.vue'
+import BaseInput from './BaseInput.vue'
+export default {
+  components: {
+    BaseButton,
+    BaseIcon,
+    BaseInput
+  }
+}
+```
+
+Just to support relatively little markup in a template:
+
+```html
+<BaseInput v-model="searchText" v-on:keydown.enter="search" />
+<BaseButton v-on:click="search">
+  <BaseIcon name="search" />
+</BaseButton>
+```
+
+Fortunately, if you're using Webpack (or [Vue CLI](https://github.com/vuejs/vue-cli), which uses Webpack internally), you can use `require.context` to globally register only these very common base components. Here's an example of the code you might use to globally import base components in your app's entry file (e.g. `src/main.js`):
+
+```js
+import { createApp } from 'vue'
+import upperFirst from 'lodash/upperFirst'
+import camelCase from 'lodash/camelCase'
+import App from './App.vue'
+
+const app = createApp(App)
+
+const requireComponent = require.context(
+  // The relative path of the components folder
+  './components',
+  // Whether or not to look in subfolders
+  false,
+  // The regular expression used to match base component filenames
+  /Base[A-Z]\w+\.(vue|js)$/
+)
+
+requireComponent.keys().forEach(fileName => {
+  // Get component config
+  const componentConfig = requireComponent(fileName)
+
+  // Get PascalCase name of component
+  const componentName = upperFirst(
+    camelCase(
+      // Gets the file name regardless of folder depth
+      fileName
+        .split('/')
+        .pop()
+        .replace(/\.\w+$/, '')
+    )
+  )
+
+  app.component(
+    componentName,
+    // Look for the component options on `.default`, which will
+    // exist if the component was exported with `export default`,
+    // otherwise fall back to module's root.
+    componentConfig.default || componentConfig
+  )
+})
+
+app.mount('#app')
+```

--- a/src/cookbook/automatic-global-registration-of-base-components.md
+++ b/src/cookbook/automatic-global-registration-of-base-components.md
@@ -28,7 +28,7 @@ Just to support relatively little markup in a template:
 </BaseButton>
 ```
 
-Fortunately, if you're using Webpack (or [Vue CLI](https://github.com/vuejs/vue-cli), which uses Webpack internally), you can use `require.context` to globally register only these very common base components. Here's an example of the code you might use to globally import base components in your app's entry file (e.g. `src/main.js`):
+Fortunately, if you're using webpack (or [Vue CLI](https://github.com/vuejs/vue-cli), which uses webpack internally), you can use `require.context` to globally register only these very common base components. Here's an example of the code you might use to globally import base components in your app's entry file (e.g. `src/main.js`):
 
 ```js
 import { createApp } from 'vue'

--- a/src/cookbook/automatic-global-registration-of-base-components.md
+++ b/src/cookbook/automatic-global-registration-of-base-components.md
@@ -22,8 +22,8 @@ export default {
 Just to support relatively little markup in a template:
 
 ```html
-<BaseInput v-model="searchText" v-on:keydown.enter="search" />
-<BaseButton v-on:click="search">
+<BaseInput v-model="searchText" @keydown.enter="search" />
+<BaseButton @click="search">
   <BaseIcon name="search" />
 </BaseButton>
 ```

--- a/src/cookbook/automatic-global-registration-of-base-components.md
+++ b/src/cookbook/automatic-global-registration-of-base-components.md
@@ -2,7 +2,7 @@
 
 ## Base Example
 
-Many of your components will be relatively generic, possibly only wrapping an element like an input or a button. We sometimes refer to these as [base components](../style-guide/#Base-component-names-strongly-recommended) and they tend to be used very frequently across your components.
+Many of your components will be relatively generic, possibly only wrapping an element like an input or a button. We sometimes refer to these as [base components](../style-guide/#base-component-names-strongly-recommended) and they tend to be used very frequently across your components.
 
 The result is that many components may include long lists of base components:
 


### PR DESCRIPTION
## Description of Problem

In #43 there is a proposal by @bencodezen to move "### Automatic Global Registration of Base Components" to Cookbook.

## Proposed Solution

I updated the Vue 2 example and added a page inside Cookbook.

## Additional Information
Related to #565 