### PR TITLE
docs: Russian translation

### DIFF
--- a/src/.vuepress/components/guide/contributing/translations-data.js
+++ b/src/.vuepress/components/guide/contributing/translations-data.js
@@ -17,6 +17,6 @@ export const repos = [
   { lang: 'ja', owner: 'vuejs-jp', repo: 'ja.vuejs.org', branch: 'lang-ja', url: 'https://v3.ja.vuejs.org/' },
   { lang: 'ko', owner: 'vuejs-kr', repo: 'docs-next', branch: 'rootKoKr', url: 'https://v3.ko.vuejs.org/'  },
   { lang: 'pt-br', owner: 'vuejs-br', repo: 'docs-next', branch: 'master', url: 'https://vuejsbr-docs-next.netlify.app/' },
-  { lang: 'ru', owner: 'translation-gang', repo: 'docs-next', branch: 'master' },
+  { lang: 'ru', owner: 'translation-gang', repo: 'docs-next', branch: 'master', url: 'https://v3.ru.vuejs.org/' },
   { lang: 'zh-cn', owner: 'vuejs', repo: 'docs-next-zh-cn', branch: 'master', url: 'https://v3.cn.vuejs.org/' }
 ]

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -435,6 +435,10 @@ module.exports = {
             link: 'https://v3.ja.vuejs.org/'
           },
           {
+            text: 'Русский',
+            link: 'https://v3.ru.vuejs.org/'
+          },
+          {
             text: 'More Translations',
             link: '/guide/contributing/translations#community-translations'
           }


### PR DESCRIPTION
Finally! :)

Some points:

It's convenient for me to save English localization files to make it easier to merge from upstream without conficts and later compare files side-by-side. That why russian locale stored in `/ru/` folder and not as default `/`

---

Links for page now contain doubled `ru`, for example `https://v3.ru.vuejs.org/ru/guide/introduction.html`. That's because vuepress didn't offer a way to pre-set default locale. Rewrite russian locale files as default locale is not useful (see above)

---

Root README.md file for english locale duplicated from russian. I don't know how to show /ru/README.md file if I need to show russian locale as default one.

---

Also had to duplicate translation here, because vuepress at start page show /README.md for english locale and not /ru/README.md for russian. And update popup also showed in english.

```
{
  serviceWorker: true,
  updatePopup: {
    '/': {
      message: 'Доступен новый контент.',
      buttonText: 'Обновить'
    },
    '/ru/': {
      message: 'Доступен новый контент.',
      buttonText: 'Обновить'
    }
  }
}
```

---

Vuepress show some pages with big empty space, but some don't (also codeblocks in headings don't have space around). See screenshots:

<img width="957" alt="Снимок экрана 2021-05-09 в 11 03 04" src="https://user-images.githubusercontent.com/4497128/117566896-ec9fbb80-b0c1-11eb-945f-a3c98b02652b.png">

<img width="1007" alt="Снимок экрана 2021-05-09 в 12 10 53" src="https://user-images.githubusercontent.com/4497128/117566816-81ee8000-b0c1-11eb-921f-bb4cd0b6dd86.png">

---

The name of the language for the code block overlaps with the content update message

<img width="942" alt="Снимок экрана 2021-05-09 в 13 50 02" src="https://user-images.githubusercontent.com/4497128/117569264-83be4080-b0cd-11eb-9e28-4f4d0ddca75f.png">

---

Also check with `vuepress-plugin-check-md` and some hashes showed as broken, but they exist and links works ok. Maybe also bug in plugin.

```
Hash is not found: [справочнике API](../api/global-api.md#аргументы-4) (translation-gang/docs-next/src/ru/guide/component-dynamic-async.md:92:43)

Hash is not found: [рекомендаций](../style-guide/#именование-базовых-компонентов-настоятельно-рекомендуется) (translation-gang/docs-next/src/ru/guide/component-registration.md:26:64)

Hash is not found: [рекомендаций](../style-guide/#избегаите-использования-v-if-с-v-for-важно) (translation-gang/docs-next/src/ru/guide/conditional.md:91:99)

Hash is not found: [вышеупомянутых](#vmodel-ime-tip) (translation-gang/docs-next/src/ru/guide/forms.md:259:86)

Hash is not found: [рекомендаций](../style-guide/#избегаите-использования-v-if-с-v-for-важно) (translation-gang/docs-next/src/ru/guide/list.md:244:115)

Hash is not found: [**должен** использоваться kebab-case](#стиль-именования-компонентов-в-шаблонах-настоятельно-рекомендуется) (translation-gang/docs-next/src/ru/style-guide/README.md:894:66)
```

---

Don't know where to start digging about this problems, but I don't have enough energy and time for that and if someone could help I will be glad for that.