### PR TITLE
Update composition-api-provide-inject.md

### DIFF
--- a/src/guide/composition-api-provide-inject.md
+++ b/src/guide/composition-api-provide-inject.md
@@ -181,7 +181,7 @@ export default {
   },
   methods: {
     updateLocation() {
-      this.location = 'South Pole'
+      location.value = 'South Pole'
     }
   }
 }


### PR DESCRIPTION
## docs: fix Options API assignment statement to Composition API

In current code snippet, the location property is updated as if it were a data property (i.e. `this.location = 'South Pole'`).
However, this example uses the Composition API rather Options API.
Therefore the line is wrong in this context, and will result in an error.

This fix edits this line to use the proper way to assign a new value to a reactive variable (i.e. `location.value = 'South Pole'`).
So if merged, this example will become correct.