### PR TITLE
Prevent CodePens from stealing focus and scrolling the page

### DIFF
--- a/src/guide/component-basics.md
+++ b/src/guide/component-basics.md
@@ -54,7 +54,7 @@ Components can be reused as many times as you want:
 </div>
 ```
 
-<common-codepen-snippet title="Component basics: reusing components" slug="rNVqYvM" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Component basics: reusing components" slug="rNVqYvM" tab="result" :preview="false" />
 
 Notice that when clicking on the buttons, each one maintains its own, separate `count`. That's because each time you use a component, a new **instance** of it is created.
 
@@ -111,7 +111,7 @@ Once a prop is registered, you can pass data to it as a custom attribute, like t
 </div>
 ```
 
-<common-codepen-snippet title="Component basics: passing props" slug="PoqyOaX" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Component basics: passing props" slug="PoqyOaX" tab="result" :preview="false" />
 
 In a typical app, however, you'll likely have an array of posts in `data`:
 
@@ -227,7 +227,7 @@ Then the child component can emit an event on itself by calling the built-in [**
 
 Thanks to the `@enlarge-text="postFontSize += 0.1"` listener, the parent will receive the event and update the value of `postFontSize`.
 
-<common-codepen-snippet title="Component basics: emitting events" slug="KKpGyrp" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Component basics: emitting events" slug="KKpGyrp" tab="result" :preview="false" />
 
 We can list emitted events in the component's `emits` option:
 

--- a/src/guide/component-dynamic-async.md
+++ b/src/guide/component-dynamic-async.md
@@ -12,7 +12,7 @@ Earlier, we used the `is` attribute to switch between components in a tabbed int
 
 When switching between these components though, you'll sometimes want to maintain their state or avoid re-rendering for performance reasons. For example, when expanding our tabbed interface a little:
 
-<common-codepen-snippet title="Dynamic components: without keep-alive" slug="jOPjZOe" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Dynamic components: without keep-alive" slug="jOPjZOe" tab="html,result" />
 
 You'll notice that if you select a post, switch to the _Archive_ tab, then switch back to _Posts_, it's no longer showing the post you selected. That's because each time you switch to a new tab, Vue creates a new instance of the `currentTabComponent`.
 
@@ -27,7 +27,7 @@ Recreating dynamic components is normally useful behavior, but in this case, we'
 
 Check out the result below:
 
-<common-codepen-snippet title="Dynamic components: with keep-alive" slug="VwLJQvP" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Dynamic components: with keep-alive" slug="VwLJQvP" tab="html,result" />
 
 Now the _Posts_ tab maintains its state (the selected post) even when it's not rendered.
 

--- a/src/guide/events.md
+++ b/src/guide/events.md
@@ -25,7 +25,7 @@ Vue.createApp({
 
 Result:
 
-<common-codepen-snippet title="Event handling: basic" slug="xxGadPZ" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Event handling: basic" slug="xxGadPZ" tab="result" :preview="false" />
 
 ## Method Event Handlers
 
@@ -62,7 +62,7 @@ Vue.createApp({
 
 Result:
 
-<common-codepen-snippet title="Event handling: with a method" slug="jOPvmaX" tab="js,result" :preview="false" />
+<common-codepen-snippet title="Event handling: with a method" slug="jOPvmaX" tab="result" :preview="false" />
 
 ## Methods in Inline Handlers
 
@@ -87,7 +87,7 @@ Vue.createApp({
 
 Result:
 
-<common-codepen-snippet title="Event handling: with an inline handler" slug="WNvgjda" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Event handling: with an inline handler" slug="WNvgjda" tab="result" :preview="false" />
 
 Sometimes we also need to access the original DOM event in an inline statement handler. You can pass it into a method using the special `$event` variable:
 

--- a/src/guide/forms.md
+++ b/src/guide/forms.md
@@ -157,7 +157,7 @@ Multiple select (bound to array):
 <span>Selected: {{ selected }}</span>
 ```
 
-<common-codepen-snippet title="Handling forms: select bound to array" slug="gOpBXPz" tab="html,result" :preview="false" />
+<common-codepen-snippet title="Handling forms: select bound to array" slug="gOpBXPz" tab="result" :preview="false" />
 
 Dynamic options rendered with `v-for`:
 

--- a/src/guide/list.md
+++ b/src/guide/list.md
@@ -217,7 +217,7 @@ methods: {
 
 Result:
 
-<common-codepen-snippet title="v-for with a range" slug="NWqLjNY" tab="html,result" :preview="false" />
+<common-codepen-snippet title="v-for with a range" slug="NWqLjNY" tab="html,result" />
 
 ## `v-for` on a `<template>`
 


### PR DESCRIPTION
Fixes #996.

Some of the CodePens were causing the page to jump when they loaded. It needed a specific set of configuration options to trigger the problem, so only a handful needed updating.

Where possible I have hidden the HTML tab by default. I used this approach whenever the HTML was already shown in a code block.

In cases where that wasn't possible I've removed the `:preview="false"`. This requires the user to click before the CodePen does anything.