### PR TITLE
Set the font-weight for strong tags back to 600

### DIFF
--- a/src/.vuepress/theme/styles/index.styl
+++ b/src/.vuepress/theme/styles/index.styl
@@ -115,7 +115,7 @@ ul, ol
   padding-left 1.2em
 
 strong
-  font-weight 500
+  font-weight 600
 
 h1, h2, h3, h4, h5, h6
   font-weight 500


### PR DESCRIPTION
Bold text currently has a `font-weight` of `500`. As noted in #844, this doesn't really stand out from normal text.

The default for VuePress is `font-weight: 600`. This same weight is used in a few other places, such as headings. A weight of `500` was introduced to the docs in #202 and #245, with the latter changing `<strong>` tags.

Having discussed this with @NataliaTepluhina and @bencodezen, it doesn't seem there's a compelling reason to continue using `font-weight: 500` for `<strong>` tags. This PR reverts it to `600`.