### PR TITLE
Elaborate on how style auto-prefixing works

### DIFF
--- a/src/guide/class-and-style.md
+++ b/src/guide/class-and-style.md
@@ -230,7 +230,7 @@ The array syntax for `:style` allows you to apply multiple style objects to the 
 
 ### Auto-prefixing
 
-When you use a CSS property that requires [vendor prefixes](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix) in `:style`, for example `transform`, Vue will automatically detect and add appropriate prefixes to the applied styles.
+When you use a CSS property that requires a [vendor prefix](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix) in `:style`, Vue will automatically add the appropriate prefix. Vue does this by checking at runtime to see which style properties are supported in the current browser. If the browser doesn't support a particular property then various prefixed variants will be tested to try to find one that is supported.
 
 ### Multiple Values
 


### PR DESCRIPTION
Closes #1059.

I've tried to give a little more detail about how the auto-prefixing of styles works. Specifically:

1. I've removed the mention of `transform` as that hasn't needed prefixing for ages.
2. I've tried to make it clearer that a prefixed style will only be included if it is required by the current browser. The previous wording may have led some people to expect to see multiple, prefixed properties, similar to what you might get in a CSS file. I think that was the underlying source of confusion in #1059.