### PR TITLE
The description of `this` in setup is inconsistent with the source code

### DIFF
--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -91,14 +91,14 @@ export default {
   props: {
     user: {
       type: String,
-      required: true,
-    },
+      required: true
+    }
   },
   setup(props) {
     console.log(props) // { user: '' }
 
     return {} // anything returned here will be available for the rest of the component
-  },
+  }
   // the "rest" of the component
 }
 ```
@@ -298,14 +298,14 @@ Whenever `counter` is modified, for example `counter.value = 5`, the watch will 
 export default {
   data() {
     return {
-      counter: 0,
+      counter: 0
     }
   },
   watch: {
     counter(newValue, oldValue) {
       console.log('The new counter value is: ' + this.counter)
-    },
-  },
+    }
+  }
 }
 ```
 
@@ -420,7 +420,7 @@ export default function useUserRepositories(user) {
 
   return {
     repositories,
-    getUserRepositories,
+    getUserRepositories
   }
 }
 ```
@@ -435,14 +435,14 @@ import { ref, computed } from 'vue'
 export default function useRepositoryNameSearch(repositories) {
   const searchQuery = ref('')
   const repositoriesMatchingSearchQuery = computed(() => {
-    return repositories.value.filter((repository) => {
+    return repositories.value.filter(repository => {
       return repository.name.includes(searchQuery.value)
     })
   })
 
   return {
     searchQuery,
-    repositoriesMatchingSearchQuery,
+    repositoriesMatchingSearchQuery
   }
 }
 ```
@@ -509,19 +509,24 @@ export default {
   props: {
     user: {
       type: String,
-      required: true,
-    },
+      required: true
+    }
   },
   setup(props) {
     const { user } = toRefs(props)
 
     const { repositories, getUserRepositories } = useUserRepositories(user)
 
-    const { searchQuery, repositoriesMatchingSearchQuery } =
-      useRepositoryNameSearch(repositories)
+    const {
+      searchQuery,
+      repositoriesMatchingSearchQuery
+    } = useRepositoryNameSearch(repositories)
 
-    const { filters, updateFilters, filteredRepositories } =
-      useRepositoryFilters(repositoriesMatchingSearchQuery)
+    const {
+      filters,
+      updateFilters,
+      filteredRepositories
+    } = useRepositoryFilters(repositoriesMatchingSearchQuery)
 
     return {
       // Since we don’t really care about the unfiltered repositories
@@ -530,9 +535,9 @@ export default {
       getUserRepositories,
       searchQuery,
       filters,
-      updateFilters,
+      updateFilters
     }
-  },
+  }
 }
 ```
 

--- a/src/guide/composition-api-introduction.md
+++ b/src/guide/composition-api-introduction.md
@@ -76,7 +76,7 @@ Now that we know the **why** we can get to the **how**. To start working with th
 The new `setup` component option is executed **before** the component is created, once the `props` are resolved, and serves as the entry point for composition API's.
 
 ::: warning
-Because the component instance is not yet created when `setup` is executed, there is no `this` inside a `setup` option. This means, with the exception of `props`, you won't be able to access any properties declared in the component – **local state**, **computed properties** or **methods**.
+Although the component instance has been created, it is not bound to `this` when the setup is executed, so `this` cannot be used in the setup, and the processing of props is also completed later, this means, with the exception of `props`, you won't be able to access any properties declared in the component – **local state**, **computed properties** or **methods**.
 :::
 
 The `setup` option should be a function that accepts `props` and `context` which we will talk about [later](composition-api-setup.html#arguments). Additionally, everything that we return from `setup` will be exposed to the rest of our component (computed properties, methods, lifecycle hooks and so on) as well as to the component's template.
@@ -91,14 +91,14 @@ export default {
   props: {
     user: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   setup(props) {
     console.log(props) // { user: '' }
 
     return {} // anything returned here will be available for the rest of the component
-  }
+  },
   // the "rest" of the component
 }
 ```
@@ -298,14 +298,14 @@ Whenever `counter` is modified, for example `counter.value = 5`, the watch will 
 export default {
   data() {
     return {
-      counter: 0
+      counter: 0,
     }
   },
   watch: {
     counter(newValue, oldValue) {
       console.log('The new counter value is: ' + this.counter)
-    }
-  }
+    },
+  },
 }
 ```
 
@@ -420,7 +420,7 @@ export default function useUserRepositories(user) {
 
   return {
     repositories,
-    getUserRepositories
+    getUserRepositories,
   }
 }
 ```
@@ -435,14 +435,14 @@ import { ref, computed } from 'vue'
 export default function useRepositoryNameSearch(repositories) {
   const searchQuery = ref('')
   const repositoriesMatchingSearchQuery = computed(() => {
-    return repositories.value.filter(repository => {
+    return repositories.value.filter((repository) => {
       return repository.name.includes(searchQuery.value)
     })
   })
 
   return {
     searchQuery,
-    repositoriesMatchingSearchQuery
+    repositoriesMatchingSearchQuery,
   }
 }
 ```
@@ -509,24 +509,19 @@ export default {
   props: {
     user: {
       type: String,
-      required: true
-    }
+      required: true,
+    },
   },
   setup(props) {
     const { user } = toRefs(props)
 
     const { repositories, getUserRepositories } = useUserRepositories(user)
 
-    const {
-      searchQuery,
-      repositoriesMatchingSearchQuery
-    } = useRepositoryNameSearch(repositories)
+    const { searchQuery, repositoriesMatchingSearchQuery } =
+      useRepositoryNameSearch(repositories)
 
-    const {
-      filters,
-      updateFilters,
-      filteredRepositories
-    } = useRepositoryFilters(repositoriesMatchingSearchQuery)
+    const { filters, updateFilters, filteredRepositories } =
+      useRepositoryFilters(repositoriesMatchingSearchQuery)
 
     return {
       // Since we don’t really care about the unfiltered repositories
@@ -535,9 +530,9 @@ export default {
       getUserRepositories,
       searchQuery,
       filters,
-      updateFilters
+      updateFilters,
     }
-  }
+  },
 }
 ```
 


### PR DESCRIPTION
## Description of Problem
According to the content of the vue3 source code, the component instance has been created when the setup is executed.
But the description in the document is not created, so `this` cannot be used.
According to the original, `this` cannot be used because this is not bound to this during setup, and props, etc. cannot be used because options such as props, data, compute, etc. will be processed later.
![Vue3 component instance is created](https://user-images.githubusercontent.com/10335230/119265374-0c35f880-bc19-11eb-8e7e-c62948188891.png)
![Execute the setup function](https://user-images.githubusercontent.com/10335230/119265393-1e179b80-bc19-11eb-971b-81e8778ff104.png)


## Proposed Solution
Modified the description information, which is relatively more accurate and will not cause misunderstandings.

## Additional Information
Thanks for the excellent documentation.
