### PR TITLE
Update positioning in lifecycle diagram

### DIFF
--- a/src/.vuepress/public/images/lifecycle.svg
+++ b/src/.vuepress/public/images/lifecycle.svg
@@ -1,147 +1,135 @@
-<svg width="840" height="1388" xmlns="http://www.w3.org/2000/svg">
-  <g fill="none" fill-rule="evenodd">
-    <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#848484">
-      <tspan x="231.593" y="1303">* Template compilation is performed ahead-of-time if using</tspan> <tspan x="270.756" y="1321.5">a build step, e.g., with single-file components.</tspan>
+<svg width="838" height="1388" xmlns="http://www.w3.org/2000/svg" fill="none" font-family="Inter,Roboto,sans-serif" font-size="14" text-anchor="middle">
+  <g transform="translate(283 63)">
+    <path d="M131 66v35h6l-7 14-7-14h6v-35h2z" fill="#9AA9B2"/>
+    <rect stroke="#2F679A" fill="#3E6B94" x="0.5" y="0.5" width="259" height="66" rx="8"/>
+    <text x="130" y="24.5" fill="#FFF" dominant-baseline="middle">
+      app = Vue.<tspan fill="#FFB196" dominant-baseline="middle">createApp</tspan>(<tspan fill="#39DD95" dominant-baseline="middle">options</tspan>)
     </text>
-    <g transform="translate(72 1056)">
-      <path d="M160 18v14l-14-7 14-7zm180 6v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3z" fill="#DB5B62" fill-rule="nonzero"/>
-      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="47" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62">
-        <tspan x="25.749" y="30">beforeUnmount</tspan>
-      </text>
-    </g>
-    <path stroke="#9AA9B2" stroke-width="2" fill="#9AA9B2" stroke-linecap="square" stroke-dasharray="1,6" d="M413 947v40"/>
-    <path d="M414 1104v2h6l-7 14-7-14h6v-2h2zm0-7v3h-2v-3h2zm0-7v3h-2v-3h2zm0-7v3h-2v-3h2zm0-7v3h-2v-3h2zm0-7v3h-2v-3h2zm0-7v3h-2v-3h2zm0-7v3h-2v-3h2z" fill="#9AA9B2" fill-rule="nonzero"/>
-    <text font-family="Inter, Roboto, sans-serif" font-size="14" transform="translate(355 947)">
-      <tspan x="39.766" y="60" fill="#8E9EA9">when </tspan> <tspan x="3.973" y="77" fill="#8E9EA9">app.</tspan> <tspan x="31.221" y="77" fill="#DB5B62">unmount</tspan> <tspan x="85.703" y="77" fill="#8E9EA9">() is </tspan> <tspan x="38.21" y="94" fill="#8E9EA9">called</tspan>
+    <text x="130" y="43" fill="#FFF" dominant-baseline="middle">
+      app.<tspan fill="#FFB196" dominant-baseline="middle">mount</tspan>(<tspan fill="#39DD95" dominant-baseline="middle">el</tspan>)
     </text>
-    <g transform="translate(72 238)">
-      <path d="M160.676 17.036l-.037 14L146.657 24l14.019-6.964zm176.231 6.459l2 .005 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 1 .003 1 .002-.005 2-1-.002-1-.003-1-.003.005-2zm-7-.018l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.006-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.006-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.006-2z" fill="#DB5B62" fill-rule="nonzero"/>
-      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="47" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62">
-        <tspan x="32.642" y="30">beforeCreate</tspan>
-      </text>
+  </g>
+  <g transform="translate(316 178)">
+    <path d="M98 58v46h6l-7 14-7-14h6v-46h2z" fill="#9AA9B2"/>
+    <rect stroke="#23AC70" fill="#3AB881" x="0.5" y="0.5" width="193" height="58" rx="8"/>
+    <text x="97" y="20.5" fill="#FFF" dominant-baseline="middle">Init</text>
+    <text x="97" y="39" fill="#FFF" dominant-baseline="middle">events &amp; lifecycle</text>
+  </g>
+  <g transform="translate(73 235)">
+    <path d="M160 18v14l-14-7l14-7z" fill="#DB5B62"/>
+    <line x1="338" y1="25" x2="161" y2="25" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
+    <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+    <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">beforeCreate</text>
+  </g>
+  <g transform="translate(316 296)">
+    <path d="M98 58v46h6l-7 14-7-14h6v-46h2z" fill="#9AA9B2"/>
+    <rect stroke="#23AC70" fill="#3AB881" x="0.5" y="0.5" width="193" height="58" rx="8"/>
+    <text x="97" y="20.5" fill="#FFF" dominant-baseline="middle">Init</text>
+    <text x="97" y="39" fill="#FFF" dominant-baseline="middle">injections &amp; reactivity</text>
+  </g>
+  <g transform="translate(73 353)">
+    <path d="M160 18v14l-14-7l14-7z" fill="#DB5B62"/>
+    <line x1="338" y1="25" x2="161" y2="25" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
+    <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+    <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">created</text>
+  </g>
+  <g transform="translate(317 414)">
+    <path d="M-45 53v52h6l-7 14-7-14h6v-54h286v54h6l-7 14-7-14h6v-52z" fill="#9AA9B2"/>
+    <polygon points="96,0.5 192,52 96,103.5 0,52" stroke="#F2781E" fill="#FF8228"/>
+    <text fill="#FFF" x="96" y="33.5" dominant-baseline="middle">Has</text>
+    <text fill="#FFF" x="96" y="52" dominant-baseline="middle">“template”</text>
+    <text fill="#FFF" x="96" y="70.5" dominant-baseline="middle">option?</text>
+    <text fill="#8E9EA9" x="-58.5" y="66.5" text-anchor="end" dominant-baseline="middle">YES</text>
+    <text fill="#8E9EA9" x="250" y="66.5" text-anchor="start" dominant-baseline="middle">NO</text>
+  </g>
+  <g transform="translate(167 533)">
+    <path d="M103 58h2v44h282v-44h2v46h-142v54h6l-7 14l-7-14h6v-54h-142z" fill="#9AA9B2"/>
+    <rect stroke="#23AC70" fill="#3AB881" x="0.5" y="0.5" width="207" height="58" rx="8"/>
+    <text fill="#FFF" x="104" y="20.5" dominant-baseline="middle">Compile template</text>
+    <text fill="#FFF" x="104" y="39" dominant-baseline="middle">into render function <tspan fill="#F6DA72" dominant-baseline="middle">*</tspan></text>
+    <g transform="translate(284 0)">
+      <rect stroke="#23AC70" fill="#3AB881" x="0.5" y="0.5" width="207" height="58" rx="8"/>
+      <text fill="#FFF" x="104" y="20.5" dominant-baseline="middle">Compile el’s innerHTML</text>
+      <text fill="#FFF" x="104" y="39" dominant-baseline="middle">as template <tspan fill="#F6DA72" dominant-baseline="middle">*</tspan></text>
     </g>
-    <g transform="translate(282 64)">
-      <path d="M132 65v35h6l-7 14-7-14h6V65h2z" fill="#9AA9B2" fill-rule="nonzero"/>
-      <rect stroke="#2F679A" fill="#3E6B94" x="-.5" y="-.5" width="259" height="66" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14">
-        <tspan x="37.555" y="28" fill="#FFF">app = Vue.</tspan> <tspan x="105.156" y="28" fill="#FFB196">createApp</tspan> <tspan x="168.976" y="28" fill="#FFF">(</tspan> <tspan x="173.638" y="28" fill="#39DD95">options</tspan> <tspan x="218.783" y="28" fill="#FFF">)</tspan> <tspan x="87.311" y="46.5" fill="#FFF">app.</tspan> <tspan x="114.559" y="46.5" fill="#FFB196">mount</tspan> <tspan x="153.469" y="46.5" fill="#FFF">(</tspan> <tspan x="158.131" y="46.5" fill="#39DD95">el</tspan> <tspan x="169.027" y="46.5" fill="#FFF">)</tspan>
-      </text>
+  </g>
+  <g transform="translate(73 639)">
+    <path d="M160 18v14l-14-7l14-7z" fill="#DB5B62"/>
+    <line x1="338" y1="25" x2="161" y2="25" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
+    <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+    <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">beforeMount</text>
+  </g>
+  <g transform="translate(316 705)">
+    <path d="M98 58v77h6l-7 14-7-14h6v-77h2z" fill="#9AA9B2"/>
+    <rect stroke="#23AC70" fill="#3AB881" x="0.5" y="0.5" width="193" height="58" rx="8"/>
+    <text x="97" y="20.5" fill="#FFF" dominant-baseline="middle">Create app.$el and</text>
+    <text x="97" y="39" fill="#FFF" dominant-baseline="middle">append it to el</text>
+  </g>
+  <g transform="translate(73 777)">
+    <path d="M160 18v14l-14-7l14-7z" fill="#DB5B62"/>
+    <line x1="338" y1="25" x2="161" y2="25" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
+    <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+    <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">mounted</text>
+  </g>
+  <g>
+    <g transform="translate(651.5 802.363) rotate(140 0 0)">
+      <path d="M14 0v14l-14-7l14-7z" fill="#DB5B62"/>
+      <line x1="60" y1="7" x2="15" y2="7" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
     </g>
-    <path d="M272 467v53h6l-7 14-7-14h6v-53h2zM554 467v53h6l-7 14-7-14h6v-53h2z" fill="#9AA9B2" fill-rule="nonzero"/>
-    <path d="M553.025 467.004h-282" stroke="#9AA9B2" stroke-width="2" fill="#9AA9B2" stroke-linecap="square"/>
-    <g fill="#9AA9B2">
-      <path stroke="#9AA9B2" stroke-width="2" stroke-linecap="square" d="M271 636v-43M553 635v-42"/>
-      <path d="M413 706l7-14h-6v-55h-2v55h-6l7 14z" fill-rule="nonzero"/>
-      <path stroke="#9AA9B2" stroke-width="2" stroke-linecap="square" d="M553 637H271"/>
+    <g transform="translate(619 747)">
+      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+      <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">beforeUpdate</text>
     </g>
-    <g transform="translate(169 535)">
-      <rect stroke="#23AC70" fill="#3AB881" x="-.5" y="-.5" width="207" height="58" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14">
-        <tspan x="49.695" y="23.918" fill="#FFF">Compile template</tspan> <tspan x="39.568" y="42.418" fill="#FFF">into render function </tspan> <tspan x="163.312" y="42.418" fill="#F6DA72">*</tspan>
-      </text>
+    <g transform="translate(642.5 1008.363) rotate(220 0 0)">
+      <path d="M14 0v14l-14-7l14-7z" fill="#DB5B62"/>
+      <line x1="60" y1="7" x2="15" y2="7" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
     </g>
-    <g transform="translate(451 535)">
-      <rect stroke="#23AC70" fill="#3AB881" x="-.5" y="-.5" width="207" height="58" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14">
-        <tspan x="29.016" y="23.918" fill="#FFF">Compile el’s innerHTML</tspan> <tspan x="62.727" y="42.418" fill="#FFF">as template </tspan> <tspan x="138.989" y="42.418" fill="#F6DA72">*</tspan>
-      </text>
+    <g transform="translate(619 1003)">
+      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+      <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">updated</text>
     </g>
-    <path d="M413 415.433L509.057 467 413 518.567 316.943 467 413 415.433z" stroke="#F2781E" fill="#FF8228"/>
-    <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#FFF" transform="translate(318 416)">
-      <tspan x="82.052" y="37.727">Has</tspan> <tspan x="38.08" y="56.227">“template” option?</tspan>
-    </text>
-    <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#8E9EA9" transform="translate(169 416)">
-      <tspan x="61.662" y="69">YES</tspan>
-    </text>
-    <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#8E9EA9" transform="translate(169 416)">
-      <tspan x="405.5" y="69">NO</tspan>
-    </text>
-    <g transform="translate(72 354)">
-      <path d="M160 17v14l-14-7 14-7zm180 6v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3z" fill="#DB5B62" fill-rule="nonzero"/>
-      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="47" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62">
-        <tspan x="50.652" y="30">created</tspan>
-      </text>
+    <path transform="translate(430 803)" stroke="#8999A4" stroke-width="2" stroke-dasharray="4" stroke-dashoffset="6" d="M147 16a95 95,0,1,1,-102 0"/>
+    <g transform="translate(539 860)">
+      <rect stroke="#23AC70" fill="#3AB881" x="0.5" y="0.5" width="141" height="77" rx="8"/>
+      <text x="71" y="20.5" fill="#FFF" dominant-baseline="middle">Virtual DOM</text>
+      <text x="71" y="39" fill="#FFF" dominant-baseline="middle">re-rendered</text>
+      <text x="71" y="57.5" fill="#FFF" dominant-baseline="middle">and patch</text>
     </g>
-    <g transform="translate(72 640)">
-      <path d="M160.676 18.036l-.037 14L146.657 25l14.019-6.964zm176.231 6.459l2 .005 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .003-.005 2-1-.003-1-.003-1-.002.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.005-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.005-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.005-2zm-7-.019l1 .003 1 .003 1 .002-.005 2-1-.002-1-.003-1-.003.005-2zm-7-.018l1 .003 2 .005-.005 2-2-.005-1-.003.005-2zm-7-.018l1 .003 1 .002 1 .003-.005 2-1-.003-1-.002-1-.003.006-2zm-7-.018l2 .005 1 .003-.005 2-1-.003-2-.005.006-2zm-7-.018l1 .002 1 .003 1 .002-.005 2-1-.002-1-.003-1-.002.006-2z" fill="#DB5B62" fill-rule="nonzero"/>
-      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="47" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62">
-        <tspan x="34.697" y="30">beforeMount</tspan>
-      </text>
+    <g transform="translate(526 803)">
+      <text x="0" y="0" fill="#8E9EA9" dominant-baseline="middle">when data</text>
+      <text x="0" y="18.5" fill="#8E9EA9" dominant-baseline="middle">changes</text>
     </g>
-    <g transform="translate(72 780)">
-      <path d="M160 18v14l-14-7 14-7zm180 6v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3z" fill="#DB5B62" fill-rule="nonzero"/>
-      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="47" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62">
-        <tspan x="46.759" y="30">mounted</tspan>
-      </text>
-    </g>
-    <g transform="translate(72 1150)">
-      <path d="M160 18v6h1v2h-1v6l-14-7 14-7zm127 6v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3zm-7 0v2h-3v-2h3z" fill="#DB5B62" fill-rule="nonzero"/>
-      <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="47" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62">
-        <tspan x="38.973" y="30">unmounted</tspan>
-      </text>
-    </g>
-    <g>
-      <g transform="translate(599 749)">
-        <path d="M2.23 85.505l1.294 1.525-.763.647-1.525 1.293-1.294-1.525.763-.647 1.525-1.293zm5.339-4.528l1.293 1.525-.762.647-.763.647-.763.647-1.293-1.526 1.525-1.293.763-.647zm5.339-4.527l1.293 1.525-1.525 1.293-.763.647-1.293-1.525.762-.647.763-.647.763-.646zm5.338-4.528l1.294 1.525-.763.647-.763.647-.762.647-1.294-1.526.763-.646 1.525-1.294zm5.339-4.528l1.293 1.526-.762.647-.763.646-.763.647-1.293-1.525.763-.647.762-.647.763-.647zm5.339-4.527l1.293 1.525-.763.647-.762.647-.763.647-1.293-1.526.762-.647.763-.646.763-.647zM48 48l-6.15 14.394-9.055-10.678L48 48zM34.262 58.34l1.294 1.525-.763.646-1.525 1.294-1.294-1.525.763-.647.763-.647.762-.647z" fill="#DB5B62" fill-rule="nonzero"/>
-        <rect stroke="#DB5B62" stroke-width="2" x="21" y="1" width="144.127" height="46.184" rx="8"/>
-        <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62">
-          <tspan x="51.101" y="28.678">beforeUpdate</tspan>
-        </text>
-      </g>
-      <path d="M642.86 988.602L649 1003l-15.203-3.726 9.062-10.672zm-8.378.759l.763.647.762.647.762.648-1.294 1.524-.763-.647-.762-.647-.762-.648 1.294-1.524zm-5.335-4.53l.762.646.762.648.762.647-1.294 1.524-.762-.647-.763-.647-.762-.647 1.295-1.525zm-5.336-4.532l.762.648.762.647.762.647-1.294 1.525-1.525-1.295-.762-.647 1.295-1.525zm-5.336-4.53l.762.647.762.647.763.647-1.295 1.525-.762-.647-1.525-1.295 1.295-1.525zm-5.336-4.531l.762.647.762.647.763.647-1.295 1.525-.762-.647-1.525-1.295 1.295-1.524zm-5.336-4.531l.762.647 1.525 1.295-1.295 1.524-.762-.647-.762-.647-.763-.648 1.295-1.524zm-5.336-4.531l.762.647.763.648.762.647-1.295 1.524-.762-.647-.762-.647-.762-.647 1.294-1.525z" fill="#DB5B62" fill-rule="nonzero"/>
-      <path d="M756.536 1004c1.933 0 3.683.784 4.95 2.05a6.978 6.978 0 012.05 4.95h0v35.184a6.978 6.978 0 01-2.05 4.95 6.978 6.978 0 01-4.95 2.05h0H627a6.978 6.978 0 01-4.95-2.05 6.978 6.978 0 01-2.05-4.95h0V1011c0-1.933.784-3.683 2.05-4.95A6.978 6.978 0 01627 1004h0z" stroke="#DB5B62" stroke-width="2"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#DB5B62" transform="translate(602 963)">
-        <tspan x="65.132" y="70">updated</tspan>
-      </text>
-      <path d="M576.785 819c6.682 3.957 12.71 8.832 18.01 14.411l-.703-.736a83.825 83.825 0 0111.52 14.047c10.695 15.46 15.754 34.304 15.367 53.281.07 17.046-4.313 34.254-13.882 49.473-7.685 12.222-17.717 22.1-29.152 29.418l-1.07.675-.693.426a94.715 94.715 0 01-15.257 7.538l-.975.373-.28.103a95.235 95.235 0 01-27.074 5.78l-.258.015-.363.024-.956.051-.709.032a95.312 95.312 0 01-33.803-4.646 94.877 94.877 0 01-15.537-6.65l-.258-.141a70.875 70.875 0 01-.93-.51l-.99-.557-.191-.112a94.409 94.409 0 01-17.315-12.745 94.131 94.131 0 01-14.775-17.444 93.788 93.788 0 01-8.463-16.035l-.38-.935-.112-.289a93.703 93.703 0 01-6.539-32.83 93.654 93.654 0 013.885-28.58l.39-1.275a93.671 93.671 0 016.442-15.556l.227-.428c.14-.265.281-.529.424-.792 6.422-11.869 15.501-22.55 27.089-31.1l.812-.593 2.62-1.936" stroke="#8999A4" stroke-width="2" stroke-dasharray="4"/>
-      <g transform="translate(519 863)">
-        <rect stroke="#23AC70" fill="#3AB881" x="20.5" y="-.5" width="139.833" height="78" rx="8"/>
-        <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#FFF">
-          <tspan x="53.006" y="25.333">Virtual DOM</tspan> <tspan x="54.424" y="43.833">re-rendered</tspan> <tspan x="60.252" y="62.333">and patch</tspan>
-        </text>
-      </g>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#8E9EA9" transform="translate(431 749)">
-        <tspan x="62.197" y="58">when data </tspan> <tspan x="71.535" y="75">changes</tspan>
-      </text>
-    </g>
-    <g transform="translate(316 179)">
-      <path d="M98 57v46h6l-7 14-7-14h6V57h2z" fill="#9AA9B2" fill-rule="nonzero"/>
-      <rect stroke="#23AC70" fill="#3AB881" x="-.5" y="-.5" width="192" height="58" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#FFF">
-        <tspan x="87.162" y="24">Init </tspan> <tspan x="42.421" y="42.5">events &amp; lifecycle</tspan>
-      </text>
-    </g>
-    <g transform="translate(316 297)">
-      <path d="M98 57v47h6l-7 14-7-14h6V57h2z" fill="#9AA9B2" fill-rule="nonzero"/>
-      <rect stroke="#23AC70" fill="#3AB881" x="-.5" y="-.5" width="192" height="58" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#FFF">
-        <tspan x="87.162" y="24">Init </tspan> <tspan x="31.142" y="42.5">injections &amp; reactivity </tspan>
-      </text>
-    </g>
-    <g transform="translate(317 707)">
-      <path d="M96.494 56.399l.01 1 .81 75.583 6-.064-6.85 14.074-7.15-13.924 6-.064-.81-75.584-.01-1 2-.021z" fill="#9AA9B2" fill-rule="nonzero"/>
-      <rect stroke="#23AC70" fill="#3AB881" x="-.5" y="-.5" width="192" height="58" rx="8"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#FFF">
-        <tspan x="36.456" y="24">Create app.$el and</tspan> <tspan x="52.148" y="42.5">append it to el</tspan>
-      </text>
-    </g>
-    <g transform="translate(367 855)">
-      <circle stroke="#DC424C" fill="#DB5860" cx="46" cy="46" r="46.5"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#FFF">
-        <tspan x="18.759" y="51">Mounted</tspan>
-      </text>
-    </g>
-    <g transform="translate(360 1121)">
-      <circle stroke="#DC424C" fill="#DB5860" cx="53" cy="53" r="53.5"/>
-      <text font-family="Inter, Roboto, sans-serif" font-size="14" fill="#FFF">
-        <tspan x="17.311" y="58">Unmounted</tspan>
-      </text>
-    </g>
+  </g>
+  <g transform="translate(366 854)">
+    <circle stroke="#DC424C" fill="#DB5860" cx="47" cy="47" r="46.5"/>
+    <text x="47" y="48" fill="#FFF" dominant-baseline="middle">Mounted</text>
+    <path stroke="#9AA9B2" stroke-width="2" stroke-dasharray="3" d="M47 96v33"/>
+  </g>
+  <g transform="translate(355 947)">
+    <text x="58" y="55" fill="#8E9EA9" dominant-baseline="middle">when</text>
+    <text x="58" y="73.5" fill="#8E9EA9" dominant-baseline="middle">app.<tspan fill="#DB5B62" dominant-baseline="middle">unmount</tspan>()</text>
+    <text x="56" y="92" fill="#8E9EA9" dominant-baseline="middle">is called</text>
+    <path stroke="#9AA9B2" stroke-width="2" stroke-dasharray="3" d="M58 107v51"/>
+    <path d="M51 159l7 14 7-14z" fill="#9AA9B2"/>
+  </g>
+  <g transform="translate(73 1056)">
+    <path d="M160 18v14l-14-7l14-7z" fill="#DB5B62"/>
+    <line x1="338" y1="25" x2="161" y2="25" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
+    <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+    <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">beforeUnmount</text>
+  </g>
+  <g transform="translate(73 1150)">
+    <path d="M160 18v14l-14-7l14-7z" fill="#DB5B62"/>
+    <line x1="338" y1="25" x2="161" y2="25" stroke="#DB5B62" stroke-width="2" stroke-dasharray="3"/>
+    <rect stroke="#DB5B62" stroke-width="2" x="1" y="1" width="144" height="48" rx="8"/>
+    <text x="73" y="25.5" fill="#DB5B62" dominant-baseline="middle">unmounted</text>
+  </g>
+  <g transform="translate(359 1120)">
+    <circle stroke="#DC424C" fill="#DB5860" cx="54" cy="54" r="53.5"/>
+    <text x="54" y="55" fill="#FFF" dominant-baseline="middle">Unmounted</text>
+  </g>
+  <g transform="translate(413 1299.5)">
+    <text x="0" y="0" fill="#848484" dominant-baseline="middle">* Template compilation is performed ahead-of-time if using</text>
+    <text x="0" y="18.5" fill="#848484" dominant-baseline="middle">a build step, e.g., with single-file components.</text>
   </g>
 </svg>


### PR DESCRIPTION
Closes #1077.

I've reworked the entire SVG but at first glance it should appear almost the same as it was before. I've nudged various things around by a pixel or two to try to make sizes and spacing a little more consistent but most of that won't be obvious unless you directly compare the old and new images. The file size is significantly smaller, though that wasn't a priority.

I've tested on Chrome, Firefox, Edge and Safari across a range of platforms and I'm not aware of any remaining problems or inconsistencies. `dominant-baseline` is probably the feature of most concern as it's a relatively new addition. While it does work fine in all of the browsers I tested, it didn't work in some non-browser image viewers I tried. This may cause the text to be positioned a few pixels too high. I don't expect this to be an issue in the docs.

The more notable visual changes are:

* The text should no longer overlap, as reported in #1077. Previously, each piece of differently-coloured text was using its own absolutely-positioned element, positioned by its top-left corner. If the fonts weren't exactly the size that was expected that could cause the text to overlap, or leave an unwanted gap. It now only absolutely positions the wrapping element and that is positioned by its midpoint.
* The text inside the orange diamond is now spread over 3 lines rather than 2.
* The line breaks in `when app.mount() is called` are now in slightly different places.

Apart from the line breaks I haven't changed the wording.

Some technical notes on my changes. These may be of interest to anyone looking to edit the code in future:

* I've tried to order the elements so they go from top to bottom. Some exceptions have to be made to ensure the arrows are behind other content. Generally I've tried to group arrows with the content that precedes them. In many cases that was what the previous version of the code was doing anyway.
* Dashed lines are now implemented using `stroke-dasharray` rather than drawing individual dashes.
* The line-height for text that spans multiple lines is now consistently 18.5px. Most of the text was using that anyway but it should now be applied everywhere.
* Safari doesn't seem to support inheritance for `dominant-baseline`, so I've had to include that on every `<text>` and `<tspan>` element to achieve the correct vertical alignment,
* Safari also doesn't properly support the `transform-origin` attribute. I originally used that for the 2 red, diagonal arrows as it made it easier to position them with an integer translation. Instead, I've used a few decimal places to get the desired positioning.